### PR TITLE
Fix piscine path -> piscine-go

### DIFF
--- a/subjects/abort.en.md
+++ b/subjects/abort.en.md
@@ -33,8 +33,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 5
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/abort.fr.md
+++ b/subjects/abort.fr.md
@@ -33,8 +33,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 5
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/activebits.en.md
+++ b/subjects/activebits.en.md
@@ -33,8 +33,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 3
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/activebits.fr.md
+++ b/subjects/activebits.fr.md
@@ -33,8 +33,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 3
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/addprimesum.en.md
+++ b/subjects/addprimesum.en.md
@@ -9,12 +9,12 @@ Write a program that takes a positive integer as argument and displays the sum o
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test 5
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test 5
 10
-student@ubuntu:~/piscine/test$ ./test 7
+student@ubuntu:~/piscine-go/test$ ./test 7
 17
-student@ubuntu:~/piscine/test$ ./test 57
+student@ubuntu:~/piscine-go/test$ ./test 57
 0
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/addprimesum.fr.md
+++ b/subjects/addprimesum.fr.md
@@ -9,12 +9,12 @@
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test 5
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test 5
 10
-student@ubuntu:~/piscine/test$ ./test 7
+student@ubuntu:~/piscine-go/test$ ./test 7
 17
-student@ubuntu:~/piscine/test$ ./test 57
+student@ubuntu:~/piscine-go/test$ ./test 57
 0
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/advancedsortwordarr.en.md
+++ b/subjects/advancedsortwordarr.en.md
@@ -35,8 +35,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 [1 2 3 A B C a b c]
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/advancedsortwordarr.fr.md
+++ b/subjects/advancedsortwordarr.fr.md
@@ -35,8 +35,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 [1 2 3 A B C a b c]
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/any.en.md
+++ b/subjects/any.en.md
@@ -40,9 +40,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 false
 true
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/any.fr.md
+++ b/subjects/any.fr.md
@@ -40,9 +40,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 false
 true
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/appendrange.en.md
+++ b/subjects/appendrange.en.md
@@ -40,9 +40,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 [5 6 7 8 9]
 []
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/appendrange.fr.md
+++ b/subjects/appendrange.fr.md
@@ -39,9 +39,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 [5 6 7 8 9]
 []
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/atoi.en.md
+++ b/subjects/atoi.en.md
@@ -63,8 +63,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 12345
 12345
 0
@@ -73,5 +73,5 @@ student@ubuntu:~/piscine/test$ ./test
 -1234
 0
 0
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/atoi.fr.md
+++ b/subjects/atoi.fr.md
@@ -63,8 +63,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 12345
 12345
 0
@@ -73,5 +73,5 @@ student@ubuntu:~/piscine/test$ ./test
 -1234
 0
 0
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/atoibase.en.md
+++ b/subjects/atoibase.en.md
@@ -48,12 +48,12 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 125
 125
 125
 125
 0
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/atoibase.fr.md
+++ b/subjects/atoibase.fr.md
@@ -48,12 +48,12 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 125
 125
 125
 125
 0
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/basicatoi.en.md
+++ b/subjects/basicatoi.en.md
@@ -48,10 +48,10 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 12345
 12345
 0
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/basicatoi.fr.md
+++ b/subjects/basicatoi.fr.md
@@ -48,10 +48,10 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 12345
 12345
 0
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/basicatoi2.en.md
+++ b/subjects/basicatoi2.en.md
@@ -52,11 +52,11 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 12345
 12345
 0
 0
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/basicatoi2.fr.md
+++ b/subjects/basicatoi2.fr.md
@@ -52,11 +52,11 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 12345
 12345
 0
 0
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/basicjoin.en.md
+++ b/subjects/basicjoin.en.md
@@ -33,8 +33,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Hello! How are you?
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/basicjoin.fr.md
+++ b/subjects/basicjoin.fr.md
@@ -33,8 +33,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Hello! How are you?
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/btreeapplyinorder.en.md
+++ b/subjects/btreeapplyinorder.en.md
@@ -38,11 +38,11 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1
 4
 5
 7
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/btreeapplyinorder.fr.md
+++ b/subjects/btreeapplyinorder.fr.md
@@ -38,11 +38,11 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1
 4
 5
 7
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/btreeapplypostorder.en.md
+++ b/subjects/btreeapplypostorder.en.md
@@ -37,11 +37,11 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1
 5
 7
 4
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/btreeapplypostorder.fr.md
+++ b/subjects/btreeapplypostorder.fr.md
@@ -37,11 +37,11 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/btreeinsertdata$ go build
-student@ubuntu:~/piscine/btreeinsertdata$ ./btreeinsertdata
+student@ubuntu:~/piscine-go/btreeinsertdata$ go build
+student@ubuntu:~/piscine-go/btreeinsertdata$ ./btreeinsertdata
 1
 5
 7
 4
-student@ubuntu:~/piscine/btreeinsertdata$
+student@ubuntu:~/piscine-go/btreeinsertdata$
 ```

--- a/subjects/btreeapplypreorder.en.md
+++ b/subjects/btreeapplypreorder.en.md
@@ -37,11 +37,11 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 4
 1
 7
 5
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/btreeapplypreorder.fr.md
+++ b/subjects/btreeapplypreorder.fr.md
@@ -37,11 +37,11 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 4
 1
 7
 5
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/btreeinsertdata.en.md
+++ b/subjects/btreeinsertdata.en.md
@@ -47,11 +47,11 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/btreeinsertdata$ go build
-student@ubuntu:~/piscine/btreeinsertdata$ ./btreeinsertdata
+student@ubuntu:~/piscine-go/btreeinsertdata$ go build
+student@ubuntu:~/piscine-go/btreeinsertdata$ ./btreeinsertdata
 1
 4
 5
 7
-student@ubuntu:~/piscine/btreeinsertdata$
+student@ubuntu:~/piscine-go/btreeinsertdata$
 ```

--- a/subjects/btreeinsertdata.fr.md
+++ b/subjects/btreeinsertdata.fr.md
@@ -46,11 +46,11 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/btreeinsertdata$ go build
-student@ubuntu:~/piscine/btreeinsertdata$ ./btreeinsertdata
+student@ubuntu:~/piscine-go/btreeinsertdata$ go build
+student@ubuntu:~/piscine-go/btreeinsertdata$ ./btreeinsertdata
 1
 4
 5
 7
-student@ubuntu:~/piscine/btreeinsertdata$
+student@ubuntu:~/piscine-go/btreeinsertdata$
 ```

--- a/subjects/btreeprintroot.en.md
+++ b/subjects/btreeprintroot.en.md
@@ -38,10 +38,10 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/printroot$ go build
-student@ubuntu:~/piscine/printroot$ ./printroot
+student@ubuntu:~/piscine-go/printroot$ go build
+student@ubuntu:~/piscine-go/printroot$ ./printroot
 who
 are
 you
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/btreeprintroot.fr.md
+++ b/subjects/btreeprintroot.fr.md
@@ -38,10 +38,10 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/printroot$ go build
-student@ubuntu:~/piscine/printroot$ ./printroot
+student@ubuntu:~/piscine-go/printroot$ go build
+student@ubuntu:~/piscine-go/printroot$ ./printroot
 who
 are
 you
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/btreesearchitem.en.md
+++ b/subjects/btreesearchitem.en.md
@@ -63,11 +63,11 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Item selected -> 7
 Parent of selected item -> 4
 Left child of selected item -> 5
 Right child of selected item -> nil
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/btreesearchitem.fr.md
+++ b/subjects/btreesearchitem.fr.md
@@ -63,11 +63,11 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Item selected -> 7
 Parent of selected item -> 4
 Left child of selected item -> 5
 Right child of selected item -> nil
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/capitalize.en.md
+++ b/subjects/capitalize.en.md
@@ -34,8 +34,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Hello! How Are You? How+Are+Things+4you?
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/capitalize.fr.md
+++ b/subjects/capitalize.fr.md
@@ -34,8 +34,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Hello! How Are You? How+Are+Things+4you?
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/cl-camp2.en.md
+++ b/subjects/cl-camp2.en.md
@@ -11,7 +11,7 @@ A line is a sequence of characters preceding the [end of line](https://en.wikipe
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ cat -e r
+student@ubuntu:~/piscine-go/test$ cat -e r
 R$
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/cl-camp2.fr.md
+++ b/subjects/cl-camp2.fr.md
@@ -11,7 +11,7 @@ Une ligne est une suite de caractères précédant le caractère [fin de ligne](
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ cat -e r
+student@ubuntu:~/piscine-go/test$ cat -e r
 R$
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/cl-camp4.en.md
+++ b/subjects/cl-camp4.en.md
@@ -17,8 +17,8 @@ Create a file `myfamily.sh`, which will show a subject's family (key: relatives)
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ export HERO_ID=1
-student@ubuntu:~/piscine/test$ ./myfamily.sh
+student@ubuntu:~/piscine-go/test$ export HERO_ID=1
+student@ubuntu:~/piscine-go/test$ ./myfamily.sh
 Marlo Chandler-Jones (wife); Polly (aunt); Mrs. Chandler (mother-in-law); Keith Chandler, Ray Chandler, three unidentified others (brothers-in-law); unidentified father (deceased); Jackie Shorr (alleged mother; unconfirmed)
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/cl-camp4.fr.md
+++ b/subjects/cl-camp4.fr.md
@@ -17,8 +17,8 @@ Créer un fichier `myfamily.sh`, qui affichera la famille d'un individu (clef: r
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ export HERO_ID=1
-student@ubuntu:~/piscine/test$ ./myfamily.sh
+student@ubuntu:~/piscine-go/test$ export HERO_ID=1
+student@ubuntu:~/piscine-go/test$ ./myfamily.sh
 Marlo Chandler-Jones (wife); Polly (aunt); Mrs. Chandler (mother-in-law); Keith Chandler, Ray Chandler, three unidentified others (brothers-in-law); unidentified father (deceased); Jackie Shorr (alleged mother; unconfirmed)
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/cl-camp5.en.md
+++ b/subjects/cl-camp5.en.md
@@ -13,11 +13,11 @@ That command will only show the name of the files without the `.sh`.
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ ./lookagain.sh | cat -e
+student@ubuntu:~/piscine-go/test$ ./lookagain.sh | cat -e
 file1$
 file2$
 file3$
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```
 
 ### Hint

--- a/subjects/cl-camp5.fr.md
+++ b/subjects/cl-camp5.fr.md
@@ -13,11 +13,11 @@ Cette commande montrera le nom des fichiers sans le`.sh`.
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ ./lookagain.sh | cat -e
+student@ubuntu:~/piscine-go/test$ ./lookagain.sh | cat -e
 file1$
 file2$
 file3$
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```
 
 ### Indice

--- a/subjects/cl-camp6.en.md
+++ b/subjects/cl-camp6.en.md
@@ -9,7 +9,7 @@ Create a file `countfiles.sh`, which will print the number **(and only the numbe
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ ./countfiles.sh | cat -e
+student@ubuntu:~/piscine-go/test$ ./countfiles.sh | cat -e
 12$
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/cl-camp6.fr.md
+++ b/subjects/cl-camp6.fr.md
@@ -9,7 +9,7 @@ Créer un fichier `countfiles.sh`, qui affichera le nombre **(et seulement le no
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ ./countfiles.sh | cat -e
+student@ubuntu:~/piscine-go/test$ ./countfiles.sh | cat -e
 12$
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/cl-camp7.en.md
+++ b/subjects/cl-camp7.en.md
@@ -9,7 +9,7 @@ Create a file `"\?$*'ChouMi'*$?\"` that will contain "01" and **nothing else**.
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ ls | cat -e
+student@ubuntu:~/piscine-go/test$ ls | cat -e
 "\?$*'ChouMi'*$?\" $
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/cl-camp7.fr.md
+++ b/subjects/cl-camp7.fr.md
@@ -9,7 +9,7 @@ Créer un fichier `"\?$*'ChouMi'*$?\"` qui contiendra "01" et **rien d'autre**.
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ ls | cat -e
+student@ubuntu:~/piscine-go/test$ ls | cat -e
 "\?$*'ChouMi'*$?\" $
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/collatzcountdown.en.md
+++ b/subjects/collatzcountdown.en.md
@@ -33,8 +33,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 10
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/comcheck.en.md
+++ b/subjects/comcheck.en.md
@@ -11,10 +11,10 @@ Write a program `comcheck` that displays on the standard output `Alert!!!` follo
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/comcheck$ go build
-student@ubuntu:~/piscine/comcheck$ ./comcheck "I" "Will" "Enter" "the" "galaxy"
+student@ubuntu:~/piscine-go/comcheck$ go build
+student@ubuntu:~/piscine-go/comcheck$ ./comcheck "I" "Will" "Enter" "the" "galaxy"
 Alert!!!
-student@ubuntu:~/piscine/comcheck$ ./comcheck "galaxy 01" "do" "you" "hear" "me"
+student@ubuntu:~/piscine-go/comcheck$ ./comcheck "galaxy 01" "do" "you" "hear" "me"
 Alert!!!
-student@ubuntu:~/piscine/comcheck$
+student@ubuntu:~/piscine-go/comcheck$
 ```

--- a/subjects/comcheck.fr.md
+++ b/subjects/comcheck.fr.md
@@ -11,10 +11,10 @@
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/comcheck$ go build
-student@ubuntu:~/piscine/comcheck$ ./comcheck "I" "Will" "Enter" "the" "galaxy"
+student@ubuntu:~/piscine-go/comcheck$ go build
+student@ubuntu:~/piscine-go/comcheck$ ./comcheck "I" "Will" "Enter" "the" "galaxy"
 Alert!!!
-student@ubuntu:~/piscine/comcheck$ ./comcheck "galaxy 01" "do" "you" "hear" "me"
+student@ubuntu:~/piscine-go/comcheck$ ./comcheck "galaxy 01" "do" "you" "hear" "me"
 Alert!!!
-student@ubuntu:~/piscine/comcheck$
+student@ubuntu:~/piscine-go/comcheck$
 ```

--- a/subjects/compact.en.md
+++ b/subjects/compact.en.md
@@ -53,8 +53,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 a
 
 b
@@ -65,5 +65,5 @@ Size after compacting: 3
 a
 b
 c
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/compact.fr.md
+++ b/subjects/compact.fr.md
@@ -53,8 +53,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 a
 
 b
@@ -65,5 +65,5 @@ Size after compacting: 3
 a
 b
 c
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/compare.en.md
+++ b/subjects/compare.en.md
@@ -34,10 +34,10 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 0
 -1
 1
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/compare.fr.md
+++ b/subjects/compare.fr.md
@@ -34,10 +34,10 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 0
 -1
 1
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/concat.en.md
+++ b/subjects/concat.en.md
@@ -33,8 +33,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Hello! How are you?
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/concat.fr.md
+++ b/subjects/concat.fr.md
@@ -33,8 +33,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Hello! How are you?
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/concatparams.en.md
+++ b/subjects/concatparams.en.md
@@ -34,11 +34,11 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Hello
 how
 are
 you?
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/concatparams.fr.md
+++ b/subjects/concatparams.fr.md
@@ -34,11 +34,11 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Hello
 how
 are
 you?
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/convertbase.en.md
+++ b/subjects/convertbase.en.md
@@ -36,8 +36,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 43
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/convertbase.fr.md
+++ b/subjects/convertbase.fr.md
@@ -36,8 +36,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 43
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/countdown.en.md
+++ b/subjects/countdown.en.md
@@ -8,8 +8,8 @@ newline(`'\n'`).
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 9876543210
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/countdown.fr.md
+++ b/subjects/countdown.fr.md
@@ -7,8 +7,8 @@
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 9876543210
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/countif.en.md
+++ b/subjects/countif.en.md
@@ -36,9 +36,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 0
 2
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/countif.fr.md
+++ b/subjects/countif.fr.md
@@ -36,9 +36,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 0
 2
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/createelem.en.md
+++ b/subjects/createelem.en.md
@@ -38,8 +38,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 &{1234}
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/createelem.fr.md
+++ b/subjects/createelem.fr.md
@@ -38,8 +38,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 &{1234}
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/displaya.en.md
+++ b/subjects/displaya.en.md
@@ -10,12 +10,12 @@ string, the program just writes `a` followed by a newline(`'\n'`). If the number
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "abc"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "abc"
 a
-student@ubuntu:~/piscine/test$ ./test "bcvbvA"
+student@ubuntu:~/piscine-go/test$ ./test "bcvbvA"
 a
-student@ubuntu:~/piscine/test$ ./test "nbv"
+student@ubuntu:~/piscine-go/test$ ./test "nbv"
 a
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/displaya.fr.md
+++ b/subjects/displaya.fr.md
@@ -7,12 +7,12 @@
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "abc"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "abc"
 a
-student@ubuntu:~/piscine/test$ ./test "bcvbvA"
+student@ubuntu:~/piscine-go/test$ ./test "bcvbvA"
 a
-student@ubuntu:~/piscine/test$ ./test "nbv"
+student@ubuntu:~/piscine-go/test$ ./test "nbv"
 a
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/displayfirstparam.en.md
+++ b/subjects/displayfirstparam.en.md
@@ -7,11 +7,11 @@ Write a program that takes `strings` as arguments, and displays its first argume
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test hello there
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test hello there
 hello
-student@ubuntu:~/piscine/test$ ./test "hello there" how are you
+student@ubuntu:~/piscine-go/test$ ./test "hello there" how are you
 hello there
-student@ubuntu:~/piscine/test$ ./test
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$ ./test
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/displayfirstparam.fr.md
+++ b/subjects/displayfirstparam.fr.md
@@ -7,11 +7,11 @@
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test hello there
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test hello there
 hello
-student@ubuntu:~/piscine/test$ ./test "hello there" how are you
+student@ubuntu:~/piscine-go/test$ ./test "hello there" how are you
 hello there
-student@ubuntu:~/piscine/test$ ./test
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$ ./test
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/displaylastparam.en.md
+++ b/subjects/displaylastparam.en.md
@@ -7,13 +7,13 @@ Write a program that takes `strings` as arguments, and displays its last argumen
 ### Expected output
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test hello there
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test hello there
 there
-student@ubuntu:~/piscine/test$ ./test "hello there" how are you
+student@ubuntu:~/piscine-go/test$ ./test "hello there" how are you
 you
-student@ubuntu:~/piscine/test$ ./test "hello there"
+student@ubuntu:~/piscine-go/test$ ./test "hello there"
 hello there
-student@ubuntu:~/piscine/test$ ./test
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$ ./test
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/displaylastparam.fr.md
+++ b/subjects/displaylastparam.fr.md
@@ -7,13 +7,13 @@
 ### Expected output
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test hello there
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test hello there
 there
-student@ubuntu:~/piscine/test$ ./test "hello there" how are you
+student@ubuntu:~/piscine-go/test$ ./test "hello there" how are you
 you
-student@ubuntu:~/piscine/test$ ./test "hello there"
+student@ubuntu:~/piscine-go/test$ ./test "hello there"
 hello there
-student@ubuntu:~/piscine/test$ ./test
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$ ./test
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/displayz.en.md
+++ b/subjects/displayz.en.md
@@ -10,12 +10,12 @@ string, the program just writes `z` followed by a newline(`'\n'`). If the number
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "xyz"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "xyz"
 z
-student@ubuntu:~/piscine/test$ ./test "bcvbvZ"
+student@ubuntu:~/piscine-go/test$ ./test "bcvbvZ"
 z
-student@ubuntu:~/piscine/test$ ./test "nbv"
+student@ubuntu:~/piscine-go/test$ ./test "nbv"
 z
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ ./test
 ```

--- a/subjects/displayz.fr.md
+++ b/subjects/displayz.fr.md
@@ -7,12 +7,12 @@
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "xyz"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "xyz"
 z
-student@ubuntu:~/piscine/test$ ./test "bcvbvZ"
+student@ubuntu:~/piscine-go/test$ ./test "bcvbvZ"
 z
-student@ubuntu:~/piscine/test$ ./test "nbv"
+student@ubuntu:~/piscine-go/test$ ./test "nbv"
 z
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ ./test
 ```

--- a/subjects/divmod.en.md
+++ b/subjects/divmod.en.md
@@ -42,9 +42,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 6
 1
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/divmod.fr.md
+++ b/subjects/divmod.fr.md
@@ -42,9 +42,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 6
 1
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/doop.en.md
+++ b/subjects/doop.en.md
@@ -21,20 +21,20 @@ The program has to handle the modulo and division operations by 0 as shown on th
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build doop.go
-student@ubuntu:~/piscine/test$ ./doop
-student@ubuntu:~/piscine/test$ ./doop 1 + 1
+student@ubuntu:~/piscine-go/test$ go build doop.go
+student@ubuntu:~/piscine-go/test$ ./doop
+student@ubuntu:~/piscine-go/test$ ./doop 1 + 1
 2
-student@ubuntu:~/piscine/test$ ./doop hello + 1 | cat -e
+student@ubuntu:~/piscine-go/test$ ./doop hello + 1 | cat -e
 0$
-student@ubuntu:~/piscine/test$ ./doop 1 p 1
+student@ubuntu:~/piscine-go/test$ ./doop 1 p 1
 0
-student@ubuntu:~/piscine/test$ ./doop 1 + 1
+student@ubuntu:~/piscine-go/test$ ./doop 1 + 1
 2
-student@ubuntu:~/piscine/test$ ./doop 1 / 0 | cat -e
+student@ubuntu:~/piscine-go/test$ ./doop 1 / 0 | cat -e
 No division by 0$
-student@ubuntu:~/piscine/test$ ./doop 1 % 0 | cat -e
+student@ubuntu:~/piscine-go/test$ ./doop 1 % 0 | cat -e
 No modulo by 0$
-student@ubuntu:~/piscine/test$ ./doop 1 "*" 1
+student@ubuntu:~/piscine-go/test$ ./doop 1 "*" 1
 1
 ```

--- a/subjects/doop.fr.md
+++ b/subjects/doop.fr.md
@@ -22,21 +22,21 @@ Le programme doit géré les opérations modulo et division par 0 comme dans les
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build doop.go
-student@ubuntu:~/piscine/test$ ./doop
-student@ubuntu:~/piscine/test$ ./doop 1 + 1
+student@ubuntu:~/piscine-go/test$ go build doop.go
+student@ubuntu:~/piscine-go/test$ ./doop
+student@ubuntu:~/piscine-go/test$ ./doop 1 + 1
 2
-student@ubuntu:~/piscine/test$ ./doop hello + 1 | cat -e
+student@ubuntu:~/piscine-go/test$ ./doop hello + 1 | cat -e
 0$
-student@ubuntu:~/piscine/test$ ./doop 1 p 1
+student@ubuntu:~/piscine-go/test$ ./doop 1 p 1
 0
-student@ubuntu:~/piscine/test$ ./doop 1 + 1
+student@ubuntu:~/piscine-go/test$ ./doop 1 + 1
 2
-student@ubuntu:~/piscine/test$ ./doop 1 / 0
+student@ubuntu:~/piscine-go/test$ ./doop 1 / 0
 No division by 0
-student@ubuntu:~/piscine/test$ ./doop 1 % 0
+student@ubuntu:~/piscine-go/test$ ./doop 1 % 0
 No modulo by 0
-student@ubuntu:~/piscine/test$ ./doop 1 * 1
+student@ubuntu:~/piscine-go/test$ ./doop 1 * 1
 1
 
 ```

--- a/subjects/eightqueens.en.md
+++ b/subjects/eightqueens.en.md
@@ -9,8 +9,8 @@ Recursivity must be used to solve this problem.
 It should print something like this :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 15863724
 16837425
 17468253

--- a/subjects/eightqueens.fr.md
+++ b/subjects/eightqueens.fr.md
@@ -9,8 +9,8 @@ La récursion doit être utilisée pour résoudre ce problème.
 L'affichage sera quelque chose comme ça :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 15863724
 16837425
 17468253

--- a/subjects/enigma.en.md
+++ b/subjects/enigma.en.md
@@ -74,8 +74,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 5
 2
 7
@@ -85,5 +85,5 @@ After using Enigma
 6
 5
 7
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/enigma.fr.md
+++ b/subjects/enigma.fr.md
@@ -73,8 +73,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 5
 2
 7
@@ -84,5 +84,5 @@ After using Enigma
 6
 5
 7
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/fibonacci.en.md
+++ b/subjects/fibonacci.en.md
@@ -43,8 +43,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 3
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/fibonacci.fr.md
+++ b/subjects/fibonacci.fr.md
@@ -43,9 +43,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$go build
+student@ubuntu:~/piscine-go/test$ ./test
 3
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 
 ```

--- a/subjects/findnextprime.en.md
+++ b/subjects/findnextprime.en.md
@@ -35,9 +35,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 5
 5
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/findnextprime.fr.md
+++ b/subjects/findnextprime.fr.md
@@ -37,9 +37,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 5
 5
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/firstrune.en.md
+++ b/subjects/firstrune.en.md
@@ -35,8 +35,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 HSO
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/firstrune.fr.md
+++ b/subjects/firstrune.fr.md
@@ -35,8 +35,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 HSO
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/firstword.en.md
+++ b/subjects/firstword.en.md
@@ -13,14 +13,14 @@ Write a program that takes a `string` and displays its first word, followed by a
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "hello there"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "hello there"
 hello
-student@ubuntu:~/piscine/test$ ./test "hello   .........  bye"
+student@ubuntu:~/piscine-go/test$ ./test "hello   .........  bye"
 hello
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ ./test
 
-student@ubuntu:~/piscine/test$ ./test "hello" "there"
+student@ubuntu:~/piscine-go/test$ ./test "hello" "there"
 
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/firstword.fr.md
+++ b/subjects/firstword.fr.md
@@ -13,14 +13,14 @@
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "hello there"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "hello there"
 hello
-student@ubuntu:~/piscine/test$ ./test "hello   .........  bye"
+student@ubuntu:~/piscine-go/test$ ./test "hello   .........  bye"
 hello
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ ./test
 
-student@ubuntu:~/piscine/test$ ./test "hello" "there"
+student@ubuntu:~/piscine-go/test$ ./test "hello" "there"
 
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/foreach.en.md
+++ b/subjects/foreach.en.md
@@ -29,8 +29,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 123456
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/foreach.fr.md
+++ b/subjects/foreach.fr.md
@@ -29,8 +29,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 123456
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/fprime.en.md
+++ b/subjects/fprime.en.md
@@ -13,18 +13,18 @@ Write a program that takes a positive `int` and displays its prime factors, foll
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test 225225
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test 225225
 3*3*5*5*7*11*13
-student@ubuntu:~/piscine/test$ ./test 8333325
+student@ubuntu:~/piscine-go/test$ ./test 8333325
 3*3*5*5*7*11*13*37
-student@ubuntu:~/piscine/test$ ./test 9539
+student@ubuntu:~/piscine-go/test$ ./test 9539
 9539
-student@ubuntu:~/piscine/test$ ./test 804577
+student@ubuntu:~/piscine-go/test$ ./test 804577
 804577
-student@ubuntu:~/piscine/test$ ./test 42
+student@ubuntu:~/piscine-go/test$ ./test 42
 2*3*7
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ ./test
 
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/fprime.fr.md
+++ b/subjects/fprime.fr.md
@@ -13,18 +13,18 @@
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test 225225
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test 225225
 3*3*5*5*7*11*13
-student@ubuntu:~/piscine/test$ ./test 8333325
+student@ubuntu:~/piscine-go/test$ ./test 8333325
 3*3*5*5*7*11*13*37
-student@ubuntu:~/piscine/test$ ./test 9539
+student@ubuntu:~/piscine-go/test$ ./test 9539
 9539
-student@ubuntu:~/piscine/test$ ./test 804577
+student@ubuntu:~/piscine-go/test$ ./test 804577
 804577
-student@ubuntu:~/piscine/test$ ./test 42
+student@ubuntu:~/piscine-go/test$ ./test 42
 2*3*7
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ ./test
 
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/hello.en.md
+++ b/subjects/hello.en.md
@@ -7,8 +7,8 @@ Write a program that displays "Hello World!" followed by a newline(`'\n'`).
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Hello World!
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/hello.fr.md
+++ b/subjects/hello.fr.md
@@ -7,8 +7,8 @@
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Hello World!
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/index.en.md
+++ b/subjects/index.en.md
@@ -34,10 +34,10 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 2
 1
 -1
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/index.fr.md
+++ b/subjects/index.fr.md
@@ -34,10 +34,10 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 2
 1
 -1
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/inter.en.md
+++ b/subjects/inter.en.md
@@ -11,10 +11,10 @@ Write a program that takes two `strings` and displays, without doubles, the char
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "padinton" "paqefwtdjetyiytjneytjoeyjnejeyj"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "padinton" "paqefwtdjetyiytjneytjoeyjnejeyj"
 padinto
-student@ubuntu:~/piscine/test$ ./test ddf6vewg64f  twthgdwthdwfteewhrtag6h4ffdhsd
+student@ubuntu:~/piscine-go/test$ ./test ddf6vewg64f  twthgdwthdwfteewhrtag6h4ffdhsd
 df6ewg4
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/inter.fr.md
+++ b/subjects/inter.fr.md
@@ -11,10 +11,10 @@
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "padinton" "paqefwtdjetyiytjneytjoeyjnejeyj"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "padinton" "paqefwtdjetyiytjneytjoeyjnejeyj"
 padinto
-student@ubuntu:~/piscine/test$ ./test ddf6vewg64f  twthgdwthdwfteewhrtag6h4ffdhsd
+student@ubuntu:~/piscine-go/test$ ./test ddf6vewg64f  twthgdwthdwfteewhrtag6h4ffdhsd
 df6ewg4
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/introduction.fr.md
+++ b/subjects/introduction.fr.md
@@ -27,9 +27,9 @@ Où `{username}` est votre `github username`
 Si l'`{username}` est `kigiri` :
 
 ```console
-user@host:~/piscine$ ./hello.sh
+user@host:~/piscine-go$ ./hello.sh
 Hello kigiri!
-user@host:~/piscine$
+user@host:~/piscine-go$
 ```
 
 #### 3- go-say-hello

--- a/subjects/isalpha.en.md
+++ b/subjects/isalpha.en.md
@@ -36,11 +36,11 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 false
 true
 false
 true
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/isalpha.fr.md
+++ b/subjects/isalpha.fr.md
@@ -36,11 +36,11 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 false
 true
 false
 true
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/islower.en.md
+++ b/subjects/islower.en.md
@@ -34,9 +34,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 true
 false
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/islower.fr.md
+++ b/subjects/islower.fr.md
@@ -34,9 +34,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 true
 false
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/isnegative.en.md
+++ b/subjects/isnegative.en.md
@@ -31,10 +31,10 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 F
 F
 T
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/isnegative.fr.md
+++ b/subjects/isnegative.fr.md
@@ -31,10 +31,10 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 F
 F
 T
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/isnumeric.en.md
+++ b/subjects/isnumeric.en.md
@@ -33,9 +33,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 true
 false
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/isnumeric.fr.md
+++ b/subjects/isnumeric.fr.md
@@ -34,9 +34,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 true
 false
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/isprime.en.md
+++ b/subjects/isprime.en.md
@@ -35,9 +35,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 true
 false
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/isprime.fr.md
+++ b/subjects/isprime.fr.md
@@ -35,9 +35,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 true
 false
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/isprintable.en.md
+++ b/subjects/isprintable.en.md
@@ -35,9 +35,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 true
 false
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/isprintable.fr.md
+++ b/subjects/isprintable.fr.md
@@ -35,9 +35,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 true
 false
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/issorted.en.md
+++ b/subjects/issorted.en.md
@@ -43,9 +43,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 true
 false
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/issorted.fr.md
+++ b/subjects/issorted.fr.md
@@ -42,9 +42,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 true
 false
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/isupper.en.md
+++ b/subjects/isupper.en.md
@@ -34,9 +34,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 true
 false
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/isupper.fr.md
+++ b/subjects/isupper.fr.md
@@ -34,8 +34,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 true
 false
 stude0t@ubuntu:~$

--- a/subjects/iterativefactorial.en.md
+++ b/subjects/iterativefactorial.en.md
@@ -35,8 +35,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 24
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/iterativefactorial.fr.md
+++ b/subjects/iterativefactorial.fr.md
@@ -35,8 +35,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 24
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/iterativepower.en.md
+++ b/subjects/iterativepower.en.md
@@ -37,8 +37,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 64
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/iterativepower.fr.md
+++ b/subjects/iterativepower.fr.md
@@ -37,8 +37,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 64
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/join.en.md
+++ b/subjects/join.en.md
@@ -33,8 +33,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Hello!: How: are: you?
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/join.fr.md
+++ b/subjects/join.fr.md
@@ -33,8 +33,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Hello!: How: are: you?
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/lastrune.en.md
+++ b/subjects/lastrune.en.md
@@ -35,8 +35,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 !!!
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/lastrune.fr.md
+++ b/subjects/lastrune.fr.md
@@ -35,8 +35,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 !!!
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listat.en.md
+++ b/subjects/listat.en.md
@@ -50,10 +50,10 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1
 how are
 <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listat.fr.md
+++ b/subjects/listat.fr.md
@@ -50,10 +50,10 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1
 how are
 <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listclear.en.md
+++ b/subjects/listclear.en.md
@@ -58,11 +58,11 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 ------list------
 I -> 1 -> something -> 2 -> <nil>
 ------updated list------
 <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listclear.fr.md
+++ b/subjects/listclear.fr.md
@@ -58,11 +58,11 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 ------list------
 I -> 1 -> something -> 2 -> <nil>
 ------updated list------
 <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listfind.en.md
+++ b/subjects/listfind.en.md
@@ -58,11 +58,11 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 0xc42000a0a0
 hello2
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```
 
 ### Note

--- a/subjects/listfind.fr.md
+++ b/subjects/listfind.fr.md
@@ -58,11 +58,11 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 0xc42000a0a0
 hello2
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```
 
 ### Note

--- a/subjects/listforeach.en.md
+++ b/subjects/listforeach.en.md
@@ -76,11 +76,11 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 12
 22
 32
 52
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listforeach.fr.md
+++ b/subjects/listforeach.fr.md
@@ -76,11 +76,11 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 12
 22
 32
 52
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listforeachif.en.md
+++ b/subjects/listforeachif.en.md
@@ -118,8 +118,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1 -> hello -> 3 -> there -> 23 -> ! -> 54 -> <nil>
 --------function applied--------
 hello
@@ -127,5 +127,5 @@ there
 !
 --------function applied--------
 1 -> 1 -> 3 -> 1 -> 23 -> 1 -> 54 -> <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listforeachif.fr.md
+++ b/subjects/listforeachif.fr.md
@@ -118,8 +118,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1 -> hello -> 3 -> there -> 23 -> ! -> 54 -> <nil>
 --------function applied--------
 hello
@@ -127,5 +127,5 @@ there
 !
 --------function applied--------
 1 -> 1 -> 3 -> 1 -> 23 -> 1 -> 54 -> <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listlast.en.md
+++ b/subjects/listlast.en.md
@@ -51,9 +51,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1
 <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listlast.fr.md
+++ b/subjects/listlast.fr.md
@@ -51,9 +51,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1
 <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listmerge.en.md
+++ b/subjects/listmerge.en.md
@@ -73,8 +73,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 a -> b -> c -> d -> e -> f -> g -> h -> <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listmerge.fr.md
+++ b/subjects/listmerge.fr.md
@@ -73,8 +73,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 a -> b -> c -> d -> e -> f -> g -> h -> <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listpushback.en.md
+++ b/subjects/listpushback.en.md
@@ -51,10 +51,10 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Hello
 man
 how are you
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listpushback.fr.md
+++ b/subjects/listpushback.fr.md
@@ -51,10 +51,10 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Hello
 man
 how are you
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listpushfront.en.md
+++ b/subjects/listpushfront.en.md
@@ -52,10 +52,10 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 how are you
 man
 Hello
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listpushfront.fr.md
+++ b/subjects/listpushfront.fr.md
@@ -52,10 +52,10 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 how are you
 man
 Hello
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listpushpara.en.md
+++ b/subjects/listpushpara.en.md
@@ -9,12 +9,12 @@ Write a program that creates a new linked list and includes each command-line ar
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./listpushparams choumi is the best cat
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./listpushparams choumi is the best cat
 cat
 best
 the
 is
 choumi
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listpushparams.en.md
+++ b/subjects/listpushparams.en.md
@@ -11,12 +11,12 @@ Write a program that creates a new linked list and includes each command-line ar
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./listpushparams choumi is the best cat
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./listpushparams choumi is the best cat
 cat
 best
 the
 is
 choumi
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ````

--- a/subjects/listpushparams.fr.md
+++ b/subjects/listpushparams.fr.md
@@ -36,9 +36,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 0
 2
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listremoveif.en.md
+++ b/subjects/listremoveif.en.md
@@ -81,8 +81,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 ----normal state----
 1 -> <nil>
 ------answer-----
@@ -92,5 +92,5 @@ student@ubuntu:~/piscine/test$ ./test
 1 -> Hello -> 1 -> There -> 1 -> 1 -> How -> 1 -> are -> you -> 1 -> <nil>
 ------answer-----
 Hello -> There -> How -> are -> you -> <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listremoveif.fr.md
+++ b/subjects/listremoveif.fr.md
@@ -81,8 +81,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 ----normal state----
 1 -> <nil>
 ------answer-----
@@ -92,5 +92,5 @@ student@ubuntu:~/piscine/test$ ./test
 1 -> Hello -> 1 -> There -> 1 -> 1 -> How -> 1 -> are -> you -> 1 -> <nil>
 ------answer-----
 Hello -> There -> How -> are -> you -> <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listreverse.en.md
+++ b/subjects/listreverse.en.md
@@ -58,13 +58,13 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 4
 3
 2
 1
 Tail &{1 <nil>}
 Head &{4 0xc42000a140}
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listreverse.fr.md
+++ b/subjects/listreverse.fr.md
@@ -58,13 +58,13 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 4
 3
 2
 1
 Tail &{1 <nil>}
 Head &{4 0xc42000a140}
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listsize.en.md
+++ b/subjects/listsize.en.md
@@ -50,8 +50,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 4
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listsize.fr.md
+++ b/subjects/listsize.fr.md
@@ -50,8 +50,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 4
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listsort.en.md
+++ b/subjects/listsort.en.md
@@ -71,8 +71,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1 -> 2 -> 3 -> 4 -> 5 -> <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/listsort.fr.md
+++ b/subjects/listsort.fr.md
@@ -71,8 +71,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1 -> 2 -> 3 -> 4 -> 5 -> <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/makerange.en.md
+++ b/subjects/makerange.en.md
@@ -39,9 +39,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 [5 6 7 8 9]
 []
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/makerange.fr.md
+++ b/subjects/makerange.fr.md
@@ -38,9 +38,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 [5 6 7 8 9]
 []
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/map.en.md
+++ b/subjects/map.en.md
@@ -33,8 +33,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 [false true true false true false]
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/map.fr.md
+++ b/subjects/map.fr.md
@@ -33,8 +33,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 [false true true false true false]
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/max.en.md
+++ b/subjects/max.en.md
@@ -34,8 +34,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 123
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/max.fr.md
+++ b/subjects/max.fr.md
@@ -34,8 +34,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 123
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/now-get-to-work.en.md
+++ b/subjects/now-get-to-work.en.md
@@ -11,9 +11,9 @@ Submit your solution in the file `my_answer.sh` that will print it when executed
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ ./my_answer.sh | cat -e
+student@ubuntu:~/piscine-go/test$ ./my_answer.sh | cat -e
 John Doe$
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```
 
 ### Hint

--- a/subjects/now-get-to-work.fr.md
+++ b/subjects/now-get-to-work.fr.md
@@ -11,9 +11,9 @@ Rendez votre solution dans un fichier `my_answer.sh` qui l'affichera quand exéc
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ ./my_answer.sh | cat -e
+student@ubuntu:~/piscine-go/test$ ./my_answer.sh | cat -e
 John Doe$
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```
 
 ### Hint

--- a/subjects/nrune.en.md
+++ b/subjects/nrune.en.md
@@ -35,8 +35,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 la!
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/nrune.fr.md
+++ b/subjects/nrune.fr.md
@@ -35,8 +35,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 la!
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/options.en.md
+++ b/subjects/options.en.md
@@ -19,16 +19,16 @@ Write a program that takes an undefined number of arguments which could be consi
 ## Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test | cat -e
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test | cat -e
 options: abcdefghijklmnopqrstuvwxyz$
-student@ubuntu:~/piscine/test$ ./test -abc -ijk | cat -e
+student@ubuntu:~/piscine-go/test$ ./test -abc -ijk | cat -e
 00000000 00000000 00000111 00000111$
-student@ubuntu:~/piscine/test$ ./test -z | cat -e
+student@ubuntu:~/piscine-go/test$ ./test -z | cat -e
 00000010 00000000 00000000 00000000$
-student@ubuntu:~/piscine/test$ ./test -abc -hijk | cat -e
+student@ubuntu:~/piscine-go/test$ ./test -abc -hijk | cat -e
 options: abcdefghijklmnopqrstuvwxyz$
-student@ubuntu:~/piscine/test$ ./test -% | cat -e
+student@ubuntu:~/piscine-go/test$ ./test -% | cat -e
 Invalid Option$
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/options.fr.md
+++ b/subjects/options.fr.md
@@ -19,16 +19,16 @@
 ## Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test | cat -e
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test | cat -e
 options: abcdefghijklmnopqrstuvwxyz$
-student@ubuntu:~/piscine/test$ ./test -abc -ijk | cat -e
+student@ubuntu:~/piscine-go/test$ ./test -abc -ijk | cat -e
 00000000 00000000 00000111 00000111$
-student@ubuntu:~/piscine/test$ ./test -z | cat -e
+student@ubuntu:~/piscine-go/test$ ./test -z | cat -e
 00000010 00000000 00000000 00000000$
-student@ubuntu:~/piscine/test$ ./test -abc -hijk | cat -e
+student@ubuntu:~/piscine-go/test$ ./test -abc -hijk | cat -e
 options: abcdefghijklmnopqrstuvwxyz$
-student@ubuntu:~/piscine/test$ ./test -% | cat -e
+student@ubuntu:~/piscine-go/test$ ./test -% | cat -e
 Invalid Option$
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/point.en.md
+++ b/subjects/point.en.md
@@ -30,8 +30,8 @@ func main() {
 ### Expected output
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 x = 42, y = 21
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/point.fr.md
+++ b/subjects/point.fr.md
@@ -31,8 +31,8 @@ func main() {
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 x = 42, y = 21
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/pointone.en.md
+++ b/subjects/pointone.en.md
@@ -34,8 +34,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/pointone.fr.md
+++ b/subjects/pointone.fr.md
@@ -34,8 +34,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/printalphabet.en.md
+++ b/subjects/printalphabet.en.md
@@ -9,8 +9,8 @@ A line is a sequence of characters preceding the [end of line](https://en.wikipe
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/printalphabet$ go build
-student@ubuntu:~/piscine/printalphabet$ ./printalphabet
+student@ubuntu:~/piscine-go/printalphabet$ go build
+student@ubuntu:~/piscine-go/printalphabet$ ./printalphabet
 abcdefghijklmnopqrstuvwxyz
-student@ubuntu:~/piscine/printalphabet$
+student@ubuntu:~/piscine-go/printalphabet$
 ```

--- a/subjects/printalphabet.fr.md
+++ b/subjects/printalphabet.fr.md
@@ -9,8 +9,8 @@ Une ligne est une suite de caractères précédant le caractère [fin de ligne](
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/printalphabet$ go build
-student@ubuntu:~/piscine/printalphabet$ ./printalphabet
+student@ubuntu:~/piscine-go/printalphabet$ go build
+student@ubuntu:~/piscine-go/printalphabet$ ./printalphabet
 abcdefghijklmnopqrstuvwxyz
-student@ubuntu:~/piscine/printalphabet$
+student@ubuntu:~/piscine-go/printalphabet$
 ```

--- a/subjects/printcomb.en.md
+++ b/subjects/printcomb.en.md
@@ -31,10 +31,10 @@ func main() {
 This is the incomplete output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 012, 013, 014, 015, 016, 017, 018, 019, 023, ..., 689, 789
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```
 
 `000` or `999` are not valid combinations because the digits are not different.

--- a/subjects/printcomb.fr.md
+++ b/subjects/printcomb.fr.md
@@ -31,10 +31,10 @@ func main() {
 Voici la sortie tronquée :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 012, 013, 014, 015, 016, 017, 018, 019, 023, ..., 689, 789
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```
 
 `000` et `999` ne sont pas des combinations valides parce que les chiffres ne sont pas différents.

--- a/subjects/printcomb2.en.md
+++ b/subjects/printcomb2.en.md
@@ -31,8 +31,8 @@ func main() {
 This is the incomplete output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 00 01, 00 02, 00 03, ..., 00 98, 00 99, 01 02, 01 03, ..., 97 98, 97 99, 98 99
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/printcomb2.fr.md
+++ b/subjects/printcomb2.fr.md
@@ -31,8 +31,8 @@ func main() {
 Voici la sortie tronquée :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 00 01, 00 02, 00 03, ..., 00 98, 00 99, 01 02, 01 03, ..., 97 98, 97 99, 98 99
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/printcombn.en.md
+++ b/subjects/printcombn.en.md
@@ -39,10 +39,10 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
 012, 013, 014, 015, 016, 017, 018, ... 679, 689, 789
 012345678, 012345679, ..., 123456789
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/printdigits.en.md
+++ b/subjects/printdigits.en.md
@@ -9,8 +9,8 @@ A line is a sequence of characters preceding the [end of line](https://en.wikipe
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/printdigits$ go build
-student@ubuntu:~/piscine/printdigits$ ./printdigits
+student@ubuntu:~/piscine-go/printdigits$ go build
+student@ubuntu:~/piscine-go/printdigits$ ./printdigits
 0123456789
-student@ubuntu:~/piscine/printdigits$
+student@ubuntu:~/piscine-go/printdigits$
 ```

--- a/subjects/printdigits.fr.md
+++ b/subjects/printdigits.fr.md
@@ -9,8 +9,8 @@ Une ligne est une suite de caractères précédant le caractère [fin de ligne](
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/printdigits$ go build
-student@ubuntu:~/piscine/printdigits$ ./printdigits
+student@ubuntu:~/piscine-go/printdigits$ go build
+student@ubuntu:~/piscine-go/printdigits$ ./printdigits
 0123456789
-student@ubuntu:~/piscine/printdigits$
+student@ubuntu:~/piscine-go/printdigits$
 ```

--- a/subjects/printhex.en.md
+++ b/subjects/printhex.en.md
@@ -9,14 +9,14 @@ Write a program that takes a positive (or zero) number expressed in base 10, and
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "10"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "10"
 a
-student@ubuntu:~/piscine/test$ ./test "255"
+student@ubuntu:~/piscine-go/test$ ./test "255"
 ff
-student@ubuntu:~/piscine/test$ ./test "5156454"
+student@ubuntu:~/piscine-go/test$ ./test "5156454"
 4eae66
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 
-student@ubuntu:~/piscine/
+student@ubuntu:~/piscine-go/
 ```

--- a/subjects/printhex.fr.md
+++ b/subjects/printhex.fr.md
@@ -9,14 +9,14 @@
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "10"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "10"
 a
-student@ubuntu:~/piscine/test$ ./test "255"
+student@ubuntu:~/piscine-go/test$ ./test "255"
 ff
-student@ubuntu:~/piscine/test$ ./test "5156454"
+student@ubuntu:~/piscine-go/test$ ./test "5156454"
 4eae66
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 
-student@ubuntu:~/piscine/
+student@ubuntu:~/piscine-go/
 ```

--- a/subjects/printmemory.en.md
+++ b/subjects/printmemory.en.md
@@ -26,11 +26,11 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test | cat -e
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test | cat -e
 6800 0000 6500 0000 6c00 0000 6c00 0000 $
 6f00 0000 1000 0000 1500 0000 2a00 0000 $
 0000 0000 0000 0000 $
 hello..*..$
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/printmemory.fr.md
+++ b/subjects/printmemory.fr.md
@@ -26,11 +26,11 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test | cat -e
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test | cat -e
 6800 0000 6500 0000 6c00 0000 6c00 0000 $
 6f00 0000 1000 0000 1500 0000 2a00 0000 $
 0000 0000 0000 0000 $
 hello..*..$
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/printnbr.en.md
+++ b/subjects/printnbr.en.md
@@ -33,8 +33,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 -1230123
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/printnbr.fr.md
+++ b/subjects/printnbr.fr.md
@@ -33,8 +33,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 -1230123
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/printnbrbase.en.md
+++ b/subjects/printnbrbase.en.md
@@ -52,12 +52,12 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 125
 -1111101
 7D
 -uoi
 NV
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/printnbrbase.fr.md
+++ b/subjects/printnbrbase.fr.md
@@ -52,12 +52,12 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 125
 -1111101
 7D
 -uoi
 NV
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/printparams.en.md
+++ b/subjects/printparams.en.md
@@ -7,12 +7,12 @@ Write a **program** that prints the arguments received in the command line.
 Example of output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./printparams choumi is the best cat
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./printparams choumi is the best cat
 choumi
 is
 the
 best
 cat
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/printparams.fr.md
+++ b/subjects/printparams.fr.md
@@ -7,12 +7,12 @@
 Exemple de résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./printparams choumi is the best cat
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./printparams choumi is the best cat
 choumi
 is
 the
 best
 cat
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/printprogramname.en.md
+++ b/subjects/printprogramname.en.md
@@ -10,5 +10,5 @@ Example of output :
 student@ubuntu:~/piscine-go/printprogramname$ go build main.go
 student@ubuntu:~/piscine-go/printprogramname$ ./main
 ./main
-student@ubuntu:~/piscine-g0/printprogramname$
+student@ubuntu:~/piscine-go/printprogramname$
 ```

--- a/subjects/printreversealphabet.en.md
+++ b/subjects/printreversealphabet.en.md
@@ -9,8 +9,8 @@ A line is a sequence of characters preceding the [end of line](https://en.wikipe
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/printreversealphabet$ go build
-student@ubuntu:~/piscine/printreversealphabet$ ./printreversealphabet
+student@ubuntu:~/piscine-go/printreversealphabet$ go build
+student@ubuntu:~/piscine-go/printreversealphabet$ ./printreversealphabet
 zyxwvutsrqponmlkjihgfedcba
-student@ubuntu:~/piscine/printreversealphabet$
+student@ubuntu:~/piscine-go/printreversealphabet$
 ```

--- a/subjects/printreversealphabet.fr.md
+++ b/subjects/printreversealphabet.fr.md
@@ -9,8 +9,8 @@ Une ligne est une suite de caractères précédant le caractère [fin de ligne](
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/printreversealphabet$ go build
-student@ubuntu:~/piscine/printreversealphabet$ ./printreversealphabet
+student@ubuntu:~/piscine-go/printreversealphabet$ go build
+student@ubuntu:~/piscine-go/printreversealphabet$ ./printreversealphabet
 zyxwvutsrqponmlkjihgfedcba
-student@ubuntu:~/piscine/printreversealphabet$
+student@ubuntu:~/piscine-go/printreversealphabet$
 ```

--- a/subjects/printstr.en.md
+++ b/subjects/printstr.en.md
@@ -30,8 +30,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Hello World!%
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/printstr.fr.md
+++ b/subjects/printstr.fr.md
@@ -30,8 +30,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Hello World!%
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/printwordstables.en.md
+++ b/subjects/printwordstables.en.md
@@ -34,11 +34,11 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build main.go
-student@ubuntu:~/piscine/test$ ./main
+student@ubuntu:~/piscine-go/test$ go build main.go
+student@ubuntu:~/piscine-go/test$ ./main
 Hello
 how
 are
 you?
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/printwordstables.fr.md
+++ b/subjects/printwordstables.fr.md
@@ -35,11 +35,11 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build main.go
-student@ubuntu:~/piscine/test$ ./main
+student@ubuntu:~/piscine-go/test$ go build main.go
+student@ubuntu:~/piscine-go/test$ ./main
 Hello
 how
 are
 you?
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/rectangle.en.md
+++ b/subjects/rectangle.en.md
@@ -48,8 +48,8 @@ func main() {
 ### Expected output
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 area of the rectangle: 6
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/rectangle.fr.md
+++ b/subjects/rectangle.fr.md
@@ -48,8 +48,8 @@ func main() {
 ### Expected output
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 area of the rectangle: 6
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/recursivefactorial.en.md
+++ b/subjects/recursivefactorial.en.md
@@ -35,8 +35,8 @@ func main() {
 ```
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 24
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/recursivefactorial.fr.md
+++ b/subjects/recursivefactorial.fr.md
@@ -37,8 +37,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 24
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/recursivepower.en.md
+++ b/subjects/recursivepower.en.md
@@ -38,8 +38,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 64
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/revparams.en.md
+++ b/subjects/revparams.en.md
@@ -7,12 +7,12 @@ Write a **program** that prints the arguments received in the command line in a 
 Example of output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./revparams choumi is the best cat
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./revparams choumi is the best cat
 cat
 best
 the
 is
 choumi
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/revparams.fr.md
+++ b/subjects/revparams.fr.md
@@ -7,12 +7,12 @@
 Exemple de résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./revparams choumi is the best cat
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./revparams choumi is the best cat
 cat
 best
 the
 is
 choumi
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/revwstr.en.md
+++ b/subjects/revwstr.en.md
@@ -13,14 +13,14 @@ Write a program that takes a `string` as a parameter, and prints its words in re
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "the time of contempt precedes that of indifference"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "the time of contempt precedes that of indifference"
 indifference of that precedes contempt of time the
-student@ubuntu:~/piscine/test$ ./test "abcdefghijklm"
+student@ubuntu:~/piscine-go/test$ ./test "abcdefghijklm"
 abcdefghijklm
-student@ubuntu:~/piscine/test$ ./test "he stared at the mountain"
+student@ubuntu:~/piscine-go/test$ ./test "he stared at the mountain"
 mountain the at stared he
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ ./test
 
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/revwstr.fr.md
+++ b/subjects/revwstr.fr.md
@@ -13,14 +13,14 @@
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "the time of contempt precedes that of indifference"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "the time of contempt precedes that of indifference"
 indifference of that precedes contempt of time the
-student@ubuntu:~/piscine/test$ ./test "abcdefghijklm"
+student@ubuntu:~/piscine-go/test$ ./test "abcdefghijklm"
 abcdefghijklm
-student@ubuntu:~/piscine/test$ ./test "he stared at the mountain"
+student@ubuntu:~/piscine-go/test$ ./test "he stared at the mountain"
 mountain the at stared he
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ ./test
 
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/rostring.en.md
+++ b/subjects/rostring.en.md
@@ -16,14 +16,14 @@ If the number of arguments is different from 1, the program displays a newline.
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/rostring$ go build
-student@ubuntu:~/piscine/rostring$ ./rostring "abc   " | cat -e
+student@ubuntu:~/piscine-go/rostring$ go build
+student@ubuntu:~/piscine-go/rostring$ ./rostring "abc   " | cat -e
 abc$
-student@ubuntu:~/piscine/rostring$ ./rostring "Let there     be light"
+student@ubuntu:~/piscine-go/rostring$ ./rostring "Let there     be light"
 there be light Let
-student@ubuntu:~/piscine/rostring$ ./rostring "     AkjhZ zLKIJz , 23y"
+student@ubuntu:~/piscine-go/rostring$ ./rostring "     AkjhZ zLKIJz , 23y"
 zLKIJz , 23y AkjhZ
-student@ubuntu:~/piscine/rostring$ ./rostring | cat -e
+student@ubuntu:~/piscine-go/rostring$ ./rostring | cat -e
 $
-student@ubuntu:~/piscine/rostring$
+student@ubuntu:~/piscine-go/rostring$
 ```

--- a/subjects/rostring.fr.md
+++ b/subjects/rostring.fr.md
@@ -15,14 +15,14 @@ Si le nombre d'arguments est différent de 1, le programme affiche un newline.
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/rostring$ go build
-student@ubuntu:~/piscine/rostring$ ./rostring "abc   " | cat -e
+student@ubuntu:~/piscine-go/rostring$ go build
+student@ubuntu:~/piscine-go/rostring$ ./rostring "abc   " | cat -e
 abc$
-student@ubuntu:~/piscine/rostring$ ./rostring "Let there     be light"
+student@ubuntu:~/piscine-go/rostring$ ./rostring "Let there     be light"
 there be light Let
-student@ubuntu:~/piscine/rostring$ ./rostring "     AkjhZ zLKIJz , 23y"
+student@ubuntu:~/piscine-go/rostring$ ./rostring "     AkjhZ zLKIJz , 23y"
 zLKIJz , 23y AkjhZ
-student@ubuntu:~/piscine/rostring$ ./rostring | cat -e
+student@ubuntu:~/piscine-go/rostring$ ./rostring | cat -e
 $
-student@ubuntu:~/piscine/rostring$
+student@ubuntu:~/piscine-go/rostring$
 ```

--- a/subjects/rot13.en.md
+++ b/subjects/rot13.en.md
@@ -14,12 +14,12 @@ letters by the letter 13 spaces ahead in alphabetical order.
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "abc"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "abc"
 nop
-student@ubuntu:~/piscine/test$ ./test "hello there"
+student@ubuntu:~/piscine-go/test$ ./test "hello there"
 uryyb gurer
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ ./test
 
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/rot13.fr.md
+++ b/subjects/rot13.fr.md
@@ -13,12 +13,12 @@
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "abc"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "abc"
 nop
-student@ubuntu:~/piscine/test$ ./test "hello there"
+student@ubuntu:~/piscine-go/test$ ./test "hello there"
 uryyb gurer
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ ./test
 
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/rot14.en.md
+++ b/subjects/rot14.en.md
@@ -40,8 +40,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Vszzc Vck ofs Mci
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/rot14.fr.md
+++ b/subjects/rot14.fr.md
@@ -40,8 +40,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 Vszzc Vck ofs Mci
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/searchreplace.en.md
+++ b/subjects/searchreplace.en.md
@@ -11,12 +11,12 @@ Write a program that takes 3 arguments, the first argument is a `string` in whic
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "hella there" "a" "o"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "hella there" "a" "o"
 hello there
-student@ubuntu:~/piscine/test$ ./test "abcd" "z" "l"
+student@ubuntu:~/piscine-go/test$ ./test "abcd" "z" "l"
 abcd
-student@ubuntu:~/piscine/test$ ./test "something" "a" "o" "b" "c"
+student@ubuntu:~/piscine-go/test$ ./test "something" "a" "o" "b" "c"
 
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/searchreplace.fr.md
+++ b/subjects/searchreplace.fr.md
@@ -11,12 +11,12 @@
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "hella there" "a" "o"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "hella there" "a" "o"
 hello there
-student@ubuntu:~/piscine/test$ ./test "abcd" "z" "l"
+student@ubuntu:~/piscine-go/test$ ./test "abcd" "z" "l"
 abcd
-student@ubuntu:~/piscine/test$ ./test "something" "a" "o" "b" "c"
+student@ubuntu:~/piscine-go/test$ ./test "something" "a" "o" "b" "c"
 
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/sortedlistmerge.en.md
+++ b/subjects/sortedlistmerge.en.md
@@ -68,8 +68,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 -2 -> 3 -> 5 -> 7 -> 9 -> <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/sortedlistmerge.fr.md
+++ b/subjects/sortedlistmerge.fr.md
@@ -68,8 +68,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 -2 -> 3 -> 5 -> 7 -> 9 -> <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/sortintegertable.en.md
+++ b/subjects/sortintegertable.en.md
@@ -34,8 +34,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 [0,1,2,3,4,5]
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/sortintegertable.fr.md
+++ b/subjects/sortintegertable.fr.md
@@ -34,8 +34,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 [0,1,2,3,4,5]
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/sortlistinsert.en.md
+++ b/subjects/sortlistinsert.en.md
@@ -69,9 +69,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1 -> 4 -> 9 -> <nil>
 -2 -> 1 -> 2 -> 4 -> 9 -> <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/sortlistinsert.fr.md
+++ b/subjects/sortlistinsert.fr.md
@@ -70,9 +70,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1 -> 4 -> 9 -> <nil>
 -2 -> 1 -> 2 -> 4 -> 9 -> <nil>
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/sortparams.en.md
+++ b/subjects/sortparams.en.md
@@ -7,8 +7,8 @@ Write a **program** that prints the arguments received in the command line in AS
 Example of output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./sortparams 1 a 2 A 3 b 4 C
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./sortparams 1 a 2 A 3 b 4 C
 1
 2
 3
@@ -17,5 +17,5 @@ A
 C
 a
 b
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/sortparams.fr.md
+++ b/subjects/sortparams.fr.md
@@ -7,8 +7,8 @@
 Exemple de résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./sortparams 1 a 2 A 3 b 4 C
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./sortparams 1 a 2 A 3 b 4 C
 1
 2
 3
@@ -17,5 +17,5 @@ A
 C
 a
 b
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/sortwordarr.en.md
+++ b/subjects/sortwordarr.en.md
@@ -35,8 +35,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 [1 2 3 A B C a b c]
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/sortwordarr.fr.md
+++ b/subjects/sortwordarr.fr.md
@@ -35,8 +35,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 [1 2 3 A B C a b c]
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/split.en.md
+++ b/subjects/split.en.md
@@ -33,8 +33,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 [Hello how are you?]
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/split.fr.md
+++ b/subjects/split.fr.md
@@ -33,8 +33,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 [Hello how are you?]
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/splitwhitespaces.en.md
+++ b/subjects/splitwhitespaces.en.md
@@ -33,8 +33,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 [Hello how are you?]
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/splitwhitespaces.fr.md
+++ b/subjects/splitwhitespaces.fr.md
@@ -33,8 +33,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 [Hello how are you?]
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/sqrt.en.md
+++ b/subjects/sqrt.en.md
@@ -36,9 +36,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 2
 0
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/sqrt.fr.md
+++ b/subjects/sqrt.fr.md
@@ -36,9 +36,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 2
 0
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/strlen.en.md
+++ b/subjects/strlen.en.md
@@ -34,8 +34,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 12
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/strlen.fr.md
+++ b/subjects/strlen.fr.md
@@ -34,8 +34,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 12
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/strrev.en.md
+++ b/subjects/strrev.en.md
@@ -36,8 +36,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 !dlroW olleH
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/strrev.fr.md
+++ b/subjects/strrev.fr.md
@@ -36,8 +36,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 !dlroW olleH
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/swap.en.md
+++ b/subjects/swap.en.md
@@ -36,9 +36,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1
 0
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/swap.fr.md
+++ b/subjects/swap.fr.md
@@ -36,9 +36,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1
 0
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/switchcase.en.md
+++ b/subjects/switchcase.en.md
@@ -13,10 +13,10 @@ Write a program that takes a `string` and reverses the case of all its letters.
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "SometHingS iS WronG"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "SometHingS iS WronG"
 sOMEThINGs Is wRONg
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ ./test
 
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/switchcase.fr.md
+++ b/subjects/switchcase.fr.md
@@ -13,10 +13,10 @@
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "SometHingS iS WronG"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "SometHingS iS WronG"
 sOMEThINGs Is wRONg
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ ./test
 
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/tabmult.en.md
+++ b/subjects/tabmult.en.md
@@ -9,8 +9,8 @@ Write a program that displays a number's multiplication table.
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test 9
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test 9
 1 x 9 = 9
 2 x 9 = 18
 3 x 9 = 27
@@ -20,7 +20,7 @@ student@ubuntu:~/piscine/test$ ./test 9
 7 x 9 = 63
 8 x 9 = 72
 9 x 9 = 81
-student@ubuntu:~/piscine/test$ ./test 19
+student@ubuntu:~/piscine-go/test$ ./test 19
 1 x 19 = 19
 2 x 19 = 38
 3 x 19 = 57
@@ -30,7 +30,7 @@ student@ubuntu:~/piscine/test$ ./test 19
 7 x 19 = 133
 8 x 19 = 152
 9 x 19 = 171
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 
-student@ubuntu:~/piscine/
+student@ubuntu:~/piscine-go/
 ```

--- a/subjects/tabmult.fr.md
+++ b/subjects/tabmult.fr.md
@@ -9,8 +9,8 @@
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test 9
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test 9
 1 x 9 = 9
 2 x 9 = 18
 3 x 9 = 27
@@ -20,7 +20,7 @@ student@ubuntu:~/piscine/test$ ./test 9
 7 x 9 = 63
 8 x 9 = 72
 9 x 9 = 81
-student@ubuntu:~/piscine/test$ ./test 19
+student@ubuntu:~/piscine-go/test$ ./test 19
 1 x 19 = 19
 2 x 19 = 38
 3 x 19 = 57
@@ -30,7 +30,7 @@ student@ubuntu:~/piscine/test$ ./test 19
 7 x 19 = 133
 8 x 19 = 152
 9 x 19 = 171
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 
-student@ubuntu:~/piscine/
+student@ubuntu:~/piscine-go/
 ```

--- a/subjects/tolower.en.md
+++ b/subjects/tolower.en.md
@@ -32,8 +32,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 hello! how are you?
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/tolower.fr.md
+++ b/subjects/tolower.fr.md
@@ -32,8 +32,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 hello! how are you?
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/toupper.en.md
+++ b/subjects/toupper.en.md
@@ -32,8 +32,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 HELLO! HOW ARE YOU?
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/toupper.fr.md
+++ b/subjects/toupper.fr.md
@@ -32,8 +32,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 HELLO! HOW ARE YOU?
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/ultimatedivmod.en.md
+++ b/subjects/ultimatedivmod.en.md
@@ -40,9 +40,9 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 6
 1
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/ultimatedivmod.fr.md
+++ b/subjects/ultimatedivmod.fr.md
@@ -40,9 +40,9 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 6
 1
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/ultimatepointone.en.md
+++ b/subjects/ultimatepointone.en.md
@@ -36,8 +36,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/ultimatepointone.fr.md
+++ b/subjects/ultimatepointone.fr.md
@@ -36,8 +36,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 1
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/unmatch.en.md
+++ b/subjects/unmatch.en.md
@@ -36,8 +36,8 @@ func main() {
 And its output :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 4
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/unmatch.fr.md
+++ b/subjects/unmatch.fr.md
@@ -34,8 +34,8 @@ func main() {
 Et son résultat :
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test
 4
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/wdmatch.en.md
+++ b/subjects/wdmatch.en.md
@@ -11,17 +11,17 @@ Write a program that takes two `strings` and checks whether it is possible to wr
 ### Usage
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "faya" "fgvvfdxcacpolhyghbreda"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "faya" "fgvvfdxcacpolhyghbreda"
 faya
-student@ubuntu:~/piscine/test$ ./test "faya" "fgvvfdxcacpolhyghbred"
+student@ubuntu:~/piscine-go/test$ ./test "faya" "fgvvfdxcacpolhyghbred"
 
-student@ubuntu:~/piscine/test$ ./test "error" rrerrrfiiljdfxjyuifrrvcoojh
+student@ubuntu:~/piscine-go/test$ ./test "error" rrerrrfiiljdfxjyuifrrvcoojh
 
-student@ubuntu:~/piscine/test$ ./test "quarante deux" "qfqfsudf arzgsayns tsregfdgs sjytdekuoixq "
+student@ubuntu:~/piscine-go/test$ ./test "quarante deux" "qfqfsudf arzgsayns tsregfdgs sjytdekuoixq "
 quarante deux
 
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ ./test
 
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```

--- a/subjects/wdmatch.fr.md
+++ b/subjects/wdmatch.fr.md
@@ -11,17 +11,17 @@
 ### Utilisation
 
 ```console
-student@ubuntu:~/piscine/test$ go build
-student@ubuntu:~/piscine/test$ ./test "faya" "fgvvfdxcacpolhyghbreda"
+student@ubuntu:~/piscine-go/test$ go build
+student@ubuntu:~/piscine-go/test$ ./test "faya" "fgvvfdxcacpolhyghbreda"
 faya
-student@ubuntu:~/piscine/test$ ./test "faya" "fgvvfdxcacpolhyghbred"
+student@ubuntu:~/piscine-go/test$ ./test "faya" "fgvvfdxcacpolhyghbred"
 
-student@ubuntu:~/piscine/test$ ./test "error" rrerrrfiiljdfxjyuifrrvcoojh
+student@ubuntu:~/piscine-go/test$ ./test "error" rrerrrfiiljdfxjyuifrrvcoojh
 
-student@ubuntu:~/piscine/test$ ./test "quarante deux" "qfqfsudf arzgsayns tsregfdgs sjytdekuoixq "
+student@ubuntu:~/piscine-go/test$ ./test "quarante deux" "qfqfsudf arzgsayns tsregfdgs sjytdekuoixq "
 quarante deux
 
-student@ubuntu:~/piscine/test$ ./test
+student@ubuntu:~/piscine-go/test$ ./test
 
-student@ubuntu:~/piscine/test$
+student@ubuntu:~/piscine-go/test$
 ```


### PR DESCRIPTION
According to the repository name mentioned in introduction.en.md `piscine-go`, the path that was shown in test outputs was `piscine`, but should be `piscine-go`. This patch changes all test outputs from "piscine" to "piscine-go".