### PR TITLE
printnbrinorder instructions correction

### DIFF
--- a/subjects/printnbrinorder.en.md
+++ b/subjects/printnbrinorder.en.md
@@ -2,7 +2,7 @@
 
 ### Instructions
 
-Write a function that prints the digits of an `int` passed in parameter in ascending order.
+Write a function which prints the digits of an `int` passed in parameter in ascending order.
 All possible values of type `int` have to go through, besides negative numbers.
 Convertion to `int64` is not allowed.
 

--- a/subjects/printnbrinorder.en.md
+++ b/subjects/printnbrinorder.en.md
@@ -2,7 +2,7 @@
 
 ### Instructions
 
-Write a function that prints an `int` passed in parameter.
+Write a function that prints digits of an `int` passed in parameter in ascending order.
 All possible values of type `int` have to go through, besides negative numbers.
 Convertion to `int64` is not allowed.
 

--- a/subjects/printnbrinorder.en.md
+++ b/subjects/printnbrinorder.en.md
@@ -2,7 +2,7 @@
 
 ### Instructions
 
-Write a function that prints digits of an `int` passed in parameter in ascending order.
+Write a function that prints the digits of an `int` passed in parameter in ascending order.
 All possible values of type `int` have to go through, besides negative numbers.
 Convertion to `int64` is not allowed.
 

--- a/subjects/printnbrinorder.fr.md
+++ b/subjects/printnbrinorder.fr.md
@@ -2,7 +2,7 @@
 
 ### Instructions
 
-Write a function that prints an `int` passed in parameter.
+Write a function that prints digits of an `int` passed in parameter in ascending order.
 All possible values of type `int` have to go through, besides negative numbers.
 Convertion to `int64` is not allowed.
 

--- a/subjects/printnbrinorder.fr.md
+++ b/subjects/printnbrinorder.fr.md
@@ -2,7 +2,7 @@
 
 ### Instructions
 
-Write a function that prints digits of an `int` passed in parameter in ascending order.
+Write a function which prints the digits of an `int` passed in parameter in ascending order.
 All possible values of type `int` have to go through, besides negative numbers.
 Convertion to `int64` is not allowed.
 


### PR DESCRIPTION
Instructions missing the condition to sort the digits in ascending order.