### PR TITLE
Removed extra quotes on raid2 examples due to leading cmd to wait for…

### DIFF
--- a/subjects/raid2.en.md
+++ b/subjects/raid2.en.md
@@ -32,11 +32,11 @@ student@ubuntu:~/piscine-go/raid2$
 Examples of output for invalid input or sudokus :
 
 ```console
-student@ubuntu:~/piscine-go/raid2$ ./raid2 1 2 3 4 +" | cat -e
+student@ubuntu:~/piscine-go/raid2$ ./raid2 1 2 3 4 | cat -e
 Error$
 student@ubuntu:~/piscine-go/raid2$ ./raid2 | cat -e
 Error$
-student@ubuntu:~/piscine-go/raid2$ ./raid2 ".96.4...1" "1...6.1.4" "5.481.39." "..795..43" ".3..8...." "4.5.23.18" ".1.63..59" ".59.7.83." "..359...7" | cat -e"
+student@ubuntu:~/piscine-go/raid2$ ./raid2 ".96.4...1" "1...6.1.4" "5.481.39." "..795..43" ".3..8...." "4.5.23.18" ".1.63..59" ".59.7.83." "..359...7" | cat -e
 Error$
 student@ubuntu:~/piscine-go/raid2$
 ```

--- a/subjects/raid2.fr.md
+++ b/subjects/raid2.fr.md
@@ -32,11 +32,11 @@ student@ubuntu:~/piscine-go/raid2$
 Examples d'outputs pour des inputs ou un sudoku invalides :
 
 ```console
-student@ubuntu:~/piscine-go/raid2$ ./raid2 1 2 3 4 +" | cat -e
+student@ubuntu:~/piscine-go/raid2$ ./raid2 1 2 3 4 | cat -e
 Error$
 student@ubuntu:~/piscine-go/raid2$ ./raid2 | cat -e
 Error$
-student@ubuntu:~/piscine-go/raid2$ ./raid2 ".96.4...1" "1...6.1.4" "5.481.39." "..795..43" ".3..8...." "4.5.23.18" ".1.63..59" ".59.7.83." "..359...7" | cat -e"
+student@ubuntu:~/piscine-go/raid2$ ./raid2 ".96.4...1" "1...6.1.4" "5.481.39." "..795..43" ".3..8...." "4.5.23.18" ".1.63..59" ".59.7.83." "..359...7" | cat -e
 Error$
 student@ubuntu:~/piscine-go/raid2$
 ```


### PR DESCRIPTION
When one types like: student@ubuntu:~/piscine-go/raid2$ ./raid2 1 2 3 4 +" | cat -e
bash is waiting for input because of that quote (") before "| cat -e".
And another moment that maybe needs to be reviewed - name of compiled file - now it is ./raid2
but according to the task repository name must be piscine-go-raid-02