### PR TITLE
Add audit question for several categories

### DIFF
--- a/subjects/forum/forum.audit.en.md
+++ b/subjects/forum/forum.audit.en.md
@@ -112,6 +112,10 @@ cc8f5dcf760f        <name of the image>    "./server"               6 seconds ag
 
 ###### Were you able to choose a category for that post?
 
+##### Try creating a post as a registered user and try to choose several categories for that post.
+
+###### Were you able to choose several categories for that post?
+
 ##### Enter the forum as a registered user and try to like or dislike a post.
 
 ###### Can you like or dislike the post?


### PR DESCRIPTION
The forum should have an option to associate several categories to a post, as per the task description. It should be checked in the audit.