### PR TITLE
fix typos

### DIFF
--- a/subjects/groupie-tracker/groupie-tracker.audit.en.md
+++ b/subjects/groupie-tracker/groupie-tracker.audit.en.md
@@ -32,7 +32,7 @@
 
 ```
     "santiago-chile"
-    "sao_paulo-usa"
+    "sao_paulo-brasil"
     "los_angeles-usa"
     "houston-usa"
     "atlanta-usa"


### PR DESCRIPTION
"sao_paulo-usa" -> "sao_paulo-brasil"