### PR TITLE
Avoids that the rc crashes when encountering more than one package in the same directory

### DIFF
--- a/go/tests/rc/rc.go
+++ b/go/tests/rc/rc.go
@@ -279,6 +279,14 @@ func loadProgram(path string, load loadedSource) error {
 		return err
 	}
 
+	if len(pkgs) > 1 {
+		packages := []string{}
+		for pkgName := range pkgs {
+			packages = append(packages, pkgName)
+		}
+		return fmt.Errorf("There should be only one package in this directory: Found packages: %v", packages)
+	}
+
 	for _, pkg := range pkgs {
 		ast.Walk(l, pkg)
 		l.pkgScope = ast.NewScope(nil)
@@ -777,6 +785,14 @@ type loadVisitor struct {
 	// used to keep the result of the createScope function
 	pkgScope *ast.Scope
 	files    map[string]*ast.File
+}
+
+func (l *loadVisitor) String() (res string) {
+	res = "files"
+	for f, _ := range l.files {
+		res += f + ","
+	}
+	return res
 }
 
 // Returns all the parameter of a function that identify a function

--- a/go/tests/rc/tests/grand-prix-go-burdeux/isnegative.go
+++ b/go/tests/rc/tests/grand-prix-go-burdeux/isnegative.go
@@ -1,0 +1,11 @@
+package piscine
+
+import "github.com/01-edu/z01"
+
+func IsNegative(nb int) {
+	if nb < 0 {
+		z01.PrintRune('T')
+	} else {
+		z01.PrintRune('F')
+	}
+}

--- a/go/tests/rc/tests/moreThanOnePackage/func.go
+++ b/go/tests/rc/tests/moreThanOnePackage/func.go
@@ -1,0 +1,5 @@
+package piscine
+
+func hello() {
+	println("Nothing here")
+}

--- a/go/tests/rc/tests/moreThanOnePackage/main.go
+++ b/go/tests/rc/tests/moreThanOnePackage/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello world")
+}

--- a/go/tests/rc/tests/testLiteralRestriction/main.go
+++ b/go/tests/rc/tests/testLiteralRestriction/main.go
@@ -1,0 +1,10 @@
+package main
+
+import "github.com/01-edu/z01"
+
+func main() {
+	alphabet := "abcdefghijklmnopqrstuvwxyz\n"
+	for _, letter := range alphabet {
+		z01.PrintRune(letter)
+	}
+}


### PR DESCRIPTION
# Why do we need this change
Some students have been submitting exercises with the wrong packages: usually mixing packages main and piscine in the same directory which causes a crash in the RC.
# What changed
I added a verification for the number of packages in the directory and an error message is displayed when more than one package is found.
# How did I came up with the solution
Since the crash is caused by a mistake in the part of the students and I cannot see a need for the RC to handle more than one package in the same directory this solution serves to avoid the crash of the RC as well as to notify of the reason of the error.