### PR TITLE
Update the adder call

### DIFF
--- a/js/tests/using-reduce_test.js
+++ b/js/tests/using-reduce_test.js
@@ -6,7 +6,7 @@ t(({ eq, ctx }) =>
   // check that the code did use reduce properly
   eq(ctx.reduceCalls[ctx.reduceCalls.length - 1], [1, 2, 3, 4])
 )
-t(({ eq }) => eq(adder([9, 24, 7, 11, 3], 10), 64))
+t(({ eq }) => eq(adder([9, 24, 7, 11, 3, 10]), 64))
 t(({ eq, ctx }) =>
   // check that the code did use reduce properly
   eq(ctx.reduceCalls[ctx.reduceCalls.length - 1], [9, 24, 7, 11, 3])


### PR DESCRIPTION
Added is called with two arguments here : 
adder([9, 24, 7, 11, 3], 10)
But the instruction given tells us that added only take one argument, an array
added is not called elswhere with two arguments
Thus : is this a typo or do the students needs to handle two arguments as well ?