### PR TITLE
Typos correction and grammar improvements

### DIFF
--- a/subjects/doop/README.md
+++ b/subjects/doop/README.md
@@ -10,7 +10,7 @@ The program has to be used with three arguments:
 - An operator, one of : `+`, `-`, `/`, `*`, `%`
 - Another value
 
-In case of an invalid operator, value, number of arguments or an overflow the programs prints nothing.
+In case of an invalid operator, value, number of arguments or an overflow, the programs prints nothing.
 
 The program has to handle the modulo and division operations by 0 as shown on the output examples below.
 

--- a/subjects/expandstr/README.md
+++ b/subjects/expandstr/README.md
@@ -2,7 +2,7 @@
 
 ### Instructions
 
-Write a program that takes a `string` and displays it with exactly three spaces between each word, with no spaces or tabs at either the beginning nor the end.
+Write a program that takes a `string` and displays it with exactly three spaces between each word, with no spaces nor tabs at neither the beginning nor the end.
 
 The `string` will be followed by a newline (`'\n'`).
 

--- a/subjects/fprime/README.md
+++ b/subjects/fprime/README.md
@@ -6,7 +6,7 @@ Write a program that takes a positive `int` and displays its prime factors, foll
 
 - Factors must be displayed in ascending order and separated by `*`.
 
-- If the number of arguments is different from 1, if the argument is invalid or if the integer doesn't have a prime factor, the program displays nothing.
+- If the number of arguments is different from 1, if the argument is invalid, or if the integer does not have a prime factor, the program displays nothing.
 
 ### Usage
 

--- a/subjects/hiddenp/README.md
+++ b/subjects/hiddenp/README.md
@@ -6,7 +6,7 @@ Write a program named `hiddenp` that takes two `string` and that, if the first `
 
 Let s1 and s2 be `string`. It is considered that s1 is hidden in s2 if it is possible to find each character from s1 in s2, **in the same order as they appear in s1.**
 
-If s1 is an empty `string` it is considered hidden in any `string`.
+If s1 is an empty `string`, it is considered hidden in any `string`.
 
 If the number of arguments is different from 2, the program displays nothing.
 

--- a/subjects/printbits/README.md
+++ b/subjects/printbits/README.md
@@ -4,7 +4,7 @@
 
 Write a program that takes a number as argument, and prints it in binary value **without a newline at the end**.
 
-- If the the argument is not a number the program should print `00000000`.
+- If the the argument is not a number, the program should print `00000000`.
 
 ### Usage :
 

--- a/subjects/printhex/README.md
+++ b/subjects/printhex/README.md
@@ -2,7 +2,7 @@
 
 ### Instructions
 
-Write a program that takes a positive (or zero) number expressed in base 10, and displays it in base 16 (with lowercase letters) followed by a newline (`'\n'`).
+Write a program that takes a positive (or zero) number expressed in base 10, and that displays it in base 16 (with lowercase letters) followed by a newline (`'\n'`).
 
 - If the number of arguments is different from 1, the program displays nothing.
 - Error cases have to be handled as shown in the example below.


### PR DESCRIPTION
Minor typos and grammar improvements for READMEs: 
1) doop
2) expandstr
3) fprime
4) hiddenp
5) printbits
6) printhex