### PR TITLE
Apply changes from #1050 to the main audit

### DIFF
--- a/subjects/make-your-game/audit/README.md
+++ b/subjects/make-your-game/audit/README.md
@@ -28,8 +28,6 @@
 
 ##### Use the Dev Tool/Performance to record and try pausing the game while it is running.
 
-###### Does the game present any frame drops?
-
 ##### Try moving the player/element using the proper commands and keys to do so.
 
 ###### Does the player obey the commands?
@@ -56,21 +54,21 @@
 
 ##### Try using the Dev Tool/Performance.
 
-###### Is there no frame drop?
+###### Can you confirm that there are no frame drops?
 
 ##### Try using the Dev Tool/Performance.
 
-###### Does the game run at or around 60fps?
+###### Does the game run at or around 60fps? (from 50 to 60 or more)
 
 ##### Try using the Dev Tool/performance and the option rendering with the paint ON, if possible.
 
-###### Is the paint being used the less possible?
+###### Can you confirm that the paint is being used as little as possible?
 
 ##### Try using the Dev Tool/performance and the option rendering with the layer ON, if possible.
 
-###### Are the layers being used the less possible?
+###### Can you confirm that the layers are being used as little as possible?
 
-###### Are the creation of the [layers being promoted](https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count) properly?
+###### Is [layer creation being promoted](https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count) properly?
 
 #### Bonus
 


### PR DESCRIPTION
A while back #1050 updated the audit questions for make-your-game-history, but NOT the main audit, hence some people were still confused:

![image](https://user-images.githubusercontent.com/7394119/167426880-e190978b-9024-48e4-ad2d-9603be9338e6.png)

These changes should also be applied to the other sub-projects (different-maps and score-handling), however I'm wondering why do they ask the same questions as the main audit. Surely if they passed those questions once they don't need to be repeatedly asked again?