### PR TITLE
Fix `Person` structure in lunch_queue

### DIFF
--- a/subjects/lunch_queue/README.md
+++ b/subjects/lunch_queue/README.md
@@ -24,7 +24,7 @@ pub struct Queue {
 pub type Link =
 
 pub struct Person {
-    pub id: i32,
+    pub discount: i32,
     pub name: String,
 }
 
@@ -32,7 +32,7 @@ impl Queue {
     pub fn new() -> Queue {
 
     }
-    pub fn add(&mut self, name: String, id: i32) {
+    pub fn add(&mut self, name: String, discount: i32) {
 
     }
     pub fn invert_queue(&mut self) {


### PR DESCRIPTION
`Person.id` was not a valid field. It was supposed to be `Person.discount`.