### PR TITLE
docs(matrix_ops): fix import typo

### DIFF
--- a/subjects/matrix_ops/README.md
+++ b/subjects/matrix_ops/README.md
@@ -28,7 +28,7 @@ impl Sub for Matrix {
 Here is a program to test your function
 
 ```rust
-use matrix_ops::*;
+use matrix::*;
 
 fn main() {
 	let matrix = Matrix(vec![vec![8, 1], vec![9, 1]]);


### PR DESCRIPTION
The wrong import was used (compared with the expected files).