### PR TITLE
fix typo in matrix_mult

### DIFF
--- a/subjects/matrix_mult/README.md
+++ b/subjects/matrix_mult/README.md
@@ -21,7 +21,7 @@ impl Matrix<T> {
 	pub fn number_of_rows(&self) -> usize {
 	}
 
-	pub fn rows(&self, n: usize) -> Vec<T> {
+	pub fn row(&self, n: usize) -> Vec<T> {
 	}
 
 	pub fn col(&self, n: usize) -> Vec<T> {


### PR DESCRIPTION
Typo in expected functions:
correct function name is `row`