### PR TITLE
CON-#### Markdown Fix `ascii` and `evenlength` subject

### DIFF
--- a/subjects/ascii/README.md
+++ b/subjects/ascii/README.md
@@ -1,0 +1,38 @@
+## ascii
+
+### Instructions
+
+Write a function that receives a string and returns a slice with the ASCII values of its characters.
+
+### Expected function
+
+```go
+func Ascii(str string) []byte {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function:
+
+```go
+package main
+
+import (
+    "piscine"
+    "fmt"
+)
+
+func main() {
+    l := piscine.Ascii("Hello")
+    fmt.Println(l)
+}
+```
+
+And its output:
+
+```console
+$ go run .
+[104 101 108 108 111]
+```

--- a/subjects/ascii/README.md
+++ b/subjects/ascii/README.md
@@ -2,7 +2,7 @@
 
 ### Instructions
 
-Write a function that receives a string and returns a slice with the ASCII values of its characters.
+Write a function that receives a string and returns a slice with the ASCII values of its characters. If the string is empty it should return an empty slice.
 
 ### Expected function
 

--- a/subjects/evenlength/README.md
+++ b/subjects/evenlength/README.md
@@ -1,0 +1,34 @@
+## evenlength
+
+### Instructions
+
+Write a function that receives a slice of strings and returns a new slice with the strings in which the length is even.
+
+### Expected function
+
+```go
+func EvenLength(strings []string) []string {
+}
+```
+
+### Usage
+
+Here is a possible program to test your function:
+
+```go
+package main
+import (
+    "fmt"
+)
+func main() {
+    l := EvenLength([]string{"Hi", "Hola", "Ola", "Ciao", "Salut", "Hallo"})
+    fmt.Println(l)
+}
+```
+
+And its output:
+
+```console
+$ go run .
+[Hi Hola Ciao]
+```


### PR DESCRIPTION
Address Miguel comments about import piscine.

Related to:
- #1266
- #1287