### PR TITLE
printstr subject: fix example output

### DIFF
--- a/subjects/printstr/README.md
+++ b/subjects/printstr/README.md
@@ -30,8 +30,7 @@ And its output :
 
 ```console
 $ go run . | cat -e
-Hello World!
-$
+Hello World!$ 
 ```
 
 ### Notions


### PR DESCRIPTION
In the example the printed string has no newline at the end: hence the shell prompt should be displayed immediately after the exclamation point (sh/bash default). An alternative modification of the example would consist in printing a percentage symbol after the bang, and the prompt on the new line (zsh behavior), like it was done in https://github.com/01-edu/public/tree/32eddefd0923a53fadb49750323f1bbb6973d39c/subjects/printstr