### PR TITLE
docs(net-cat): make bonus title visible in the subject

### DIFF
--- a/subjects/net-cat/README.md
+++ b/subjects/net-cat/README.md
@@ -178,7 +178,7 @@ _)      \.___.,|     .'
 [2020-01-20 16:04:57][Lee]:^C
 ```
 
-## Bonus
+### Bonus
 
 - Terminal UI (you are allowed to use only this package : https://github.com/jroimartin/gocui).
 - Find a way to save all the logs into a file.


### PR DESCRIPTION
This issue was pointed out by a student and confirmed by checking in our preview tool.
At the moment it raises two questions:
- Why H2 have `display: none` rule in css
- Why we do add the name of the exercise as `H2` at the start of the subjects

If by any chance you know the answers please let me know