### PR TITLE
docs(ascii-art-optionals): clarify subjects

### DIFF
--- a/subjects/ascii-art/color/README.md
+++ b/subjects/ascii-art/color/README.md
@@ -16,6 +16,9 @@ Usage: go run . [STRING] [OPTION]
 EX: go run . something --color=<color>
 ```
 
+If there are other `ascii-art` optional projects implemented, the program should accept other correctly formatted `[OPTION]` and/or `[BANNER]`.  
+Additionally, the program must still be able to run with a single `[STRING]` argument.
+
 ### Instructions
 
 - Your project must be written in **Go**.

--- a/subjects/ascii-art/fs/README.md
+++ b/subjects/ascii-art/fs/README.md
@@ -18,6 +18,9 @@ Usage: go run . [STRING] [BANNER]
 EX: go run . something standard
 ```
 
+If there are other `ascii-art` optional projects implemented, the program should accept other correctly formatted `[OPTION]` and/or `[BANNER]`.  
+Additionally, the program must still be able to run with a single `[STRING]` argument.
+
 ### Usage
 
 ```console

--- a/subjects/ascii-art/justify/README.md
+++ b/subjects/ascii-art/justify/README.md
@@ -27,6 +27,9 @@ Usage: go run . [STRING] [BANNER] [OPTION]
 Example: go run . something standard --align=right
 ```
 
+If there are other `ascii-art` optional projects implemented, the program should accept other correctly formatted `[OPTION]` and/or `[BANNER]`.  
+Additionally, the program must still be able to run with a single `[STRING]` argument.
+
 ### Instructions
 
 - Your project must be written in **Go**.

--- a/subjects/ascii-art/output/README.md
+++ b/subjects/ascii-art/output/README.md
@@ -14,6 +14,9 @@ Usage: go run . [STRING] [BANNER] [OPTION]
 EX: go run . something standard --output=<fileName.txt>
 ```
 
+If there are other `ascii-art` optional projects implemented, the program should accept other correctly formatted `[OPTION]` and/or `[BANNER]`.  
+Additionally, the program must still be able to run with a single `[STRING]` argument.
+
 ### Instructions
 
 - Your project must be written in **Go**.

--- a/subjects/ascii-art/reverse/README.md
+++ b/subjects/ascii-art/reverse/README.md
@@ -16,6 +16,9 @@ Usage: go run . [OPTION]
 EX: go run . --reverse=<fileName>
 ```
 
+If there are other `ascii-art` optional projects implemented, the program should accept other correctly formatted `[OPTION]` and/or `[BANNER]`.  
+Additionally, the program must still be able to run with a single `[STRING]` argument.
+
 ### Instructions
 
 - Your project must be written in **Go**.


### PR DESCRIPTION
- Specify the behavior for programs with multiple optional projects implemented to avoid doubts during audits
- Add clarification on default behaviour - program with only [STRING] argument