### PR TITLE
go-reloaded audit: quote input text in input

### DIFF
--- a/subjects/go-reloaded/audit/README.md
+++ b/subjects/go-reloaded/audit/README.md
@@ -2,25 +2,25 @@
 
 ###### Has the requirement for the allowed packages been respected? (Reminder for this project: (only [standard packages](https://golang.org/pkg/))
 
-##### In a file called `sample.txt`, place the following text (without the double quotes): "If I make you BREAKFAST IN BED (low, 3) just say thank you instead of: how (cap) did you get in my house (up, 2) ?". Now run the student program with the arguments: `sample.txt result.txt`.
+##### In a file called `sample.txt`, place the following text: `If I make you BREAKFAST IN BED (low, 3) just say thank you instead of: how (cap) did you get in my house (up, 2) ?`. Now run the student program with the arguments: `sample.txt result.txt`.
 
 `If I make you breakfast in bed just say thank you instead of: How did you get in MY HOUSE?`
 
 ###### Is the text present in `result.txt` equal to the above?
 
-##### In a file called `sample.txt` place the following text (without the double quotes): "I have to pack 101 (bin) outfits. Packed 1a (hex) just to be sure". Now run the student program with the arguments: `sample.txt result.txt`.
+##### In a file called `sample.txt` place the following text: `I have to pack 101 (bin) outfits. Packed 1a (hex) just to be sure`. Now run the student program with the arguments: `sample.txt result.txt`.
 
 `I have to pack 5 outfits. Packed 26 just to be sure`
 
 ###### Is the text present in `result.txt` equal to the above?
 
-##### In a file called `sample.txt` place the following text (without the double quotes): "Don not be sad ,because sad backwards is das . And das not good". Now run the student program with the arguments: `sample.txt result.txt`.
+##### In a file called `sample.txt` place the following text: `Don not be sad ,because sad backwards is das . And das not good`. Now run the student program with the arguments: `sample.txt result.txt`.
 
 `Don not be sad, because sad backwards is das. And das not good`
 
 ###### Is the text present in `result.txt` equal to the above?
 
-##### In a file called `sample.txt` place the following text (without the double quotes): "harold wilson (cap, 2) : ' I am a optimist ,but a optimist who carries a raincoat . '". Now run the student program with the arguments: `sample.txt result.txt`.
+##### In a file called `sample.txt` place the following text: `harold wilson (cap, 2) : ' I am a optimist ,but a optimist who carries a raincoat . '`. Now run the student program with the arguments: `sample.txt result.txt`.
 
 `Harold Wilson: 'I am an optimist, but an optimist who carries a raincoat.'`
 


### PR DESCRIPTION
Quick fix for #1515
Wraps every input text in a markdown inline quote, this should not let the quotes in the last examples be transformed in their curly version.