### PR TITLE
issue-1657-quadcheckerdocs(quadchecker): changing the word raid to quad in the readme and a…

### DIFF
--- a/subjects/quadchecker/README.md
+++ b/subjects/quadchecker/README.md
@@ -6,7 +6,7 @@ This raid is based on the `quad` functions.
 
 Create a program `quadchecker` that takes a `string` as an argument and displays the name of the matching `quad` and its dimensions.
 
-- If the argument is not a `raid` the program should print `Not a Raid function`.
+- If the argument is not a `quad` the program should print `Not a quad function`.
 
 - All answers must end with a newline (`'\n'`).
 
@@ -60,14 +60,14 @@ $ ./quadE 1 2 | go run .
 $
 ```
 
-- If it's not a raid function:
+- If it's not a quad function:
 
 ```console
 $ echo 0 0 | go run .
-Not a Raid function
+Not a quad function
 $ echo -n "o--o"$'\n'"|"$'\n'"o"
 o--o
 |
 o$ echo -n "o--o"$'\n'"|"$'\n'"o" | go run .
-Not a Raid function
+Not a quad function
 ```

--- a/subjects/quadchecker/audit/README.md
+++ b/subjects/quadchecker/audit/README.md
@@ -1,6 +1,6 @@
 #### Quadrangle Checker
 
-> ***NOTE: If you are an admin and you want to test this project, follow the instructions [in the this subject](https://github.com/01-edu/go-tests/blob/master/raid-testing.md) before you proceed to the questions.***
+> **_NOTE: If you are an admin and you want to test this project, follow the instructions [in the this subject](https://github.com/01-edu/go-tests/blob/master/raid-testing.md) before you proceed to the questions._**
 
 ##### Open the repository of the project and check the submitted files
 
@@ -73,7 +73,7 @@
 ##### Try running the program: `"echo 0 0 | ./quadchecker"`
 
 ```
-Not a Raid function
+Not a quad function
 ```
 
 ###### Does the program returns the value above?
@@ -81,7 +81,7 @@ Not a Raid function
 ##### Try running the program: `"echo -n "o--" | ./quadchecker"`
 
 ```
-Not a Raid function
+Not a quad function
 ```
 
 ###### Does the program returns the value above?
@@ -89,7 +89,7 @@ Not a Raid function
 ##### Try running the program: `"echo -n "/****" | ./quadchecker"`
 
 ```
-Not a Raid function
+Not a quad function
 ```
 
 ###### Does the program returns the value above?
@@ -97,7 +97,7 @@ Not a Raid function
 ##### Try running the program: `"echo -n "ABBB" | ./quadchecker"`
 
 ```
-Not a Raid function
+Not a quad function
 ```
 
 ###### Does the program returns the value above?
@@ -105,7 +105,7 @@ Not a Raid function
 ##### Try running the program: `"echo -n "ABBBA"$'\n'"B"$'\n'"B" | ./quadchecker"`
 
 ```
-Not a Raid function
+Not a quad function
 ```
 
 ###### Does the program returns the value above?
@@ -113,7 +113,7 @@ Not a Raid function
 ##### Try running the program: `"echo -n "o--o"$'\n'"|"$'\n'"o" | ./quadchecker"`
 
 ```
-Not a Raid function
+Not a quad function
 ```
 
 ###### Does the program returns the value above?


### PR DESCRIPTION
changing the word raid to quad in the readme and audit