### PR TITLE
new line in the beginning of output removed

### DIFF
--- a/subjects/crossword/README.md
+++ b/subjects/crossword/README.md
@@ -24,15 +24,13 @@ const emptyPuzzle =
 `2001
 0..0
 1000
-0..0
-`
+0..0`
 const words = ['casa', 'alan', 'ciao', 'anta']
 
 crosswordSolver(emptyPuzzle, words)
 
 /* output:
-`
-casa
+`casa
 i..l
 anta
 o..n`


### PR DESCRIPTION
new line in the beginning of output removed as it is not consistent with the audit questions

> Before starting, please choose the relevant pull request **Labels**, **Reviewers**, and **Assignees**

### Why?

> Students can get confused by this mistake of putting a new line at the beginning of the output and at the end of input. There is no explanation about it and it seems like a typo as it is inconsistent with the audits as well

### Solution Overview

> removed the unnecessary empty lines from the string literals

### Implementation Details

> 2 back tabs were clicked and 2 lines were removed from string literals
