### PR TITLE
[EXTERNAL] 100 random test cases for split

### DIFF
--- a/js/tests/unbreakable_test.js
+++ b/js/tests/unbreakable_test.js
@@ -15,6 +15,15 @@ t(({ eq }) => eq(split('rrirr', 'rr'), ['', 'i', '']))
 t(({ eq }) => eq(split('Riad', ''), ['R', 'i', 'a', 'd']))
 t(({ eq }) => eq(split('', 'Riad'), ['']))
 
+///// HARDCODING PREVENTION //////
+for (let i = 0; i < 100; i++) {
+    t(({eq}) => {
+        const randomString = Array.from({length: Math.floor(Math.random() * 100) + 1}, () => String.fromCharCode(Math.floor(Math.random() * 26) + 97)).join('');
+        const randomDelimiter = randomString[Math.floor(Math.random() * randomString.length)];
+        return eq(split(randomString, randomDelimiter), randomString.split(randomDelimiter))
+    });
+}
+
 t(() => join(['ee', 'ff', 'g', ''], ',') === 'ee,ff,g,')
 t(() => join(['ggg', 'ddd', 'b'], ' - ') === 'ggg - ddd - b')
 t(() => join(['a', 'b', 'c'], ' ') === 'a b c')


### PR DESCRIPTION
100 random test cases are added to the split function to prevent hardcoding. As the tests were previously defined, it was very easy to hardcode against them.

> Before starting, please choose the relevant pull request **Labels**, **Reviewers**, and **Assignees**

### Why?

> One could easily check the input and give the output by putting an if statement. It is important to prevent hardcoding.

### Solution Overview

> We generate a random string in each test generation in the for loop.
> We select a random character from that string to use as a string splitter.
> We compare the output of the user-made function with the in-built function.

### Implementation Details

> Considered this approach also: https://medium.com/@gabescholz/randomized-testing-in-javascript-without-lifting-a-finger-8d616d7048af
> Considered if more edge cases should also be randomized separately.
> The 100 iterations are randomly chosen with hope that at-least some good edge cases will be generated. However, there was no logic behind choosing 100 iterations or behind choosing string length between 1 to 100.
