### PR TITLE
covering -0 cases as well

### DIFF
--- a/js/tests/cut-corners_test.js
+++ b/js/tests/cut-corners_test.js
@@ -2,7 +2,7 @@ Math.round = Math.ceil = Math.floor = Math.trunc = undefined
 // /*/ // ⚡
 export const tests = []
 const t = (f) => tests.push(f)
-const nums = [Math.PI, -Math.PI, Math.E, -Math.E, 0]
+const nums = [Math.PI, -Math.PI, Math.E, -Math.E, 0, -0.01]
 
 t(({ code }) => !/String|['"`]|toFixed|slice/.test(code))
 t(({ code }) => !code.includes('~'))
@@ -12,10 +12,10 @@ t(({ code }) => !/[^|]\|[^|]/.test(code))
 t(({ code }) => !/[^&]&[^&]/.test(code))
 t(({ code }) => !code.includes('parseInt'))
 
-t(({ eq }) => eq(nums.map(round), [3, -3, 3, -3, 0]))
-t(({ eq }) => eq(nums.map(floor), [3, -4, 2, -3, 0]))
-t(({ eq }) => eq(nums.map(trunc), [3, -3, 2, -2, 0]))
-t(({ eq }) => eq(nums.map(ceil), [4, -3, 3, -2, 0]))
+t(({ eq }) => eq(nums.map(round), [3, -3, 3, -3, 0, -0]))
+t(({ eq }) => eq(nums.map(floor), [3, -4, 2, -3, 0, -1]))
+t(({ eq }) => eq(nums.map(trunc), [3, -3, 2, -2, 0, -0]))
+t(({ eq }) => eq(nums.map(ceil), [4, -3, 3, -2, 0, -0]))
 t(({ ctx }) => trunc(0xfffffffff + ctx) === 0xfffffffff + ~~ctx)
 
 export const setup = () => Math.random() * 10


### PR DESCRIPTION
as Math.round will give -0 when input is -0.01, it is an interesting behavioral nuance of Javascript that should be fun to cover as well.

> Before starting, please choose the relevant pull request **Labels**, **Reviewers**, and **Assignees**

### Why?

> Many people can round -0 to 0 for example. This can give everyone an opportunity to have more fun with Javascript.

### Solution Overview

> Added a case of -0.01 in the test cases, and defined the expected outputs as from Math.round, Math.floor, Math.trunc and Math.ceil

### Implementation Details

> Nothing much has changed. Core implementation remains the same with one more case added.
