### PR TITLE
class to classe

### DIFF
--- a/subjects/get-them-all/README.md
+++ b/subjects/get-them-all/README.md
@@ -19,7 +19,7 @@ Complete the body of the following functions. The first three functions return a
   - 2nd array: all the non-architects.
 
 - `getClassical`:
-  - 1st array: the architects belonging to the `classical` class.
+  - 1st array: the architects belonging to the `classical` classe.
   - 2nd array: the non-classical architects.
 
 - `getActive`:


### PR DESCRIPTION
class to classe as in the attached js object, there is no class tag, only classe tag mentioned. This confuses a lot of non-French speakers.

> Before starting, please choose the relevant pull request **Labels**, **Reviewers**, and **Assignees**

### Why?

> Classe tag is present as a classifier rather than the class tag. Non-french speakers (including me) waste disproportionate amount of time to know this mistake.

### Solution Overview

> Changed class to classe in the task description

### Implementation Details

> The alternative was to change the tag itself. As that would make many lines changed, I leave it to the wisdom of the merger-reviewer. If they want, they can reject this pull request and use the alternate method, i.e. correct the tag name from classe to class. If that method is not used, then we need to correct the task description which this request does.
