### PR TITLE
DEV-4309 race bring issue from public

### DIFF
--- a/js/tests/race_test.js
+++ b/js/tests/race_test.js
@@ -1,6 +1,3 @@
-// @davhojt commented out Promise.race as a quick fix.
-// @eslopfer is working on a fix on a fix on branch: DEV-4309-race-bring-issue-from-public
-// Promise.race = undefined
 // /*/ // ⚡
 export const tests = []
 const t = (f) => tests.push(f)

--- a/js/tests/test.mjs
+++ b/js/tests/test.mjs
@@ -175,12 +175,15 @@ const runTests = async ({ url, path, code }) => {
   let timeout
   for (const [i, t] of tests.entries()) {
     try {
-      const waitWithTimeout = Promise.race([
+      const testWithTimeout = [
         t(tools),
         new Promise((s, f) => {
           timeout = setTimeout(f, 60000, Error('Time limit reached (1min)'))
         }),
-    ])
+      ]
+      const waitWithTimeout = Promise.race
+        ? Promise.race(testWithTimeout)
+        : Promise.race_(testWithTimeout)
       if (!(await waitWithTimeout) && !isDOM) {
         throw Error('Test failed')
       }

--- a/js/tests/test.mjs
+++ b/js/tests/test.mjs
@@ -175,15 +175,12 @@ const runTests = async ({ url, path, code }) => {
   let timeout
   for (const [i, t] of tests.entries()) {
     try {
-      const testWithTimeout = [
+      const waitWithTimeout = Promise.race([
         t(tools),
         new Promise((s, f) => {
           timeout = setTimeout(f, 60000, Error('Time limit reached (1min)'))
         }),
-      ]
-      const waitWithTimeout = Promise.race
-        ? Promise.race(testWithTimeout)
-        : Promise.race_(testWithTimeout)
+      ])
       if (!(await waitWithTimeout) && !isDOM) {
         throw Error('Test failed')
       }


### PR DESCRIPTION


### Why?

When running the solution you always get the same error `Promise.race is undefined`

### Solution Overview

Promise.race was set to undefined in the test of the exercise, and because the script that runs the tests uses it it would always show an error. The solution I proposed is to save it in another property and  check  whether Promise.race is undefined when running the tests.

### Implementation Details

Assuming the reason to set this method to undefined is to avoid 'cheating', other ways this could be implemented could be to obfuscate the name of Promise.race_ to something more meaningless, and perhaps store it outside of  `Promise`.
Another possible way could be to implement the functionality from scratch, but this would be the actual solution for the exercise and it could also  be copied, so it would defeat the purpose of preventing cheating.

My opinion is that we can't prevent cheating in all scenarios. It's very likely there will always be a way. I think that making it not the path of less resistance is enough, that's why I chose the current implementation. I am against obfuscating code, since code should be written to be read, and we are already preventing the easy 'cheat' of using the built in method.
