### PR TITLE
[EXTERNAL] Condition in tests but not in task description

### DIFF
--- a/subjects/pick-omit/README.md
+++ b/subjects/pick-omit/README.md
@@ -3,6 +3,7 @@
 ### Instructions
 
 Create two functions which takes an object and a string or array of strings. They should return a new object which:
+
 - `pick`: contains only those keys which appear in the string or array of strings.
 - `omit`: contains only those keys which do not match the string, or do not appear in the array of strings.
 

--- a/subjects/pick-omit/README.md
+++ b/subjects/pick-omit/README.md
@@ -7,6 +7,7 @@ Create two functions which takes an object and a string or array of strings. The
 - `omit`: contains only those keys which do not match the string, or do not appear in the array of strings.
 
 > Those functions are pure and must not modify the given object
+> It should ignore properties from the prototype chain
 
 ### Notions
 


### PR DESCRIPTION
I have added the condition that was not included in the task description but was included in the tests. also __proto__ is  a non standard property.
It maybe good to mention as the first test usually fails just because it is not mentioned to ignore the properties from the prototype chain.

### Why?

> Impovement in task description needed
