### PR TITLE
Reference link returns 404

### DIFF
--- a/js/tests/test.mjs
+++ b/js/tests/test.mjs
@@ -11,7 +11,6 @@ global.window = global
 global._fetch = fetch
 global.fetch = url => {
   // this is a fake implementation of fetch for the tester
-  // -> refer to https://devdocs.io/javascript/global_objects/fetch
   const accessBody = async () => { throw Error('body unavailable') }
   return {
     ok: false,


### PR DESCRIPTION
The reference links returns 404. There is nothing in wayback machine also about the reference link.

I propose if the proposal is rejected, find a working reference link to put.