### PR TITLE
DEV-4412 docs(make-your-game): add missing question

### DIFF
--- a/subjects/make-your-game/audit/README.md
+++ b/subjects/make-your-game/audit/README.md
@@ -28,6 +28,8 @@
 
 ##### Use the Dev Tool/Performance to record and try pausing the game while it is running.
 
+###### Can you confirm there aren't any dropped frames, and requestAnimationFrame is able to run at the same rate unaffected?
+
 ##### Try moving the player/element using the proper commands and keys to do so.
 
 ###### Does the player obey the commands?


### PR DESCRIPTION
There was an instruction that was making the next instruction confusing, so I added the question that seemed to be missing between both.
