### PR TITLE
DEV-4430 Add `runner` v2 support

### DIFF
--- a/sh/debian/configure.sh
+++ b/sh/debian/configure.sh
@@ -258,9 +258,23 @@ function deployCore() {
   # Deploy Runner
   echo -e "Deploying Runner service: \n "
   cd /root/core/runner
+
+  # Get the latest release version tag and create latest branch
+  tag=$(git describe --tags $(git rev-list --tags --max-count=1))
+  git checkout $tag -b latest
+  git describe --tags
+
+  # Set upstream to latest
+  git branch --set-upstream-to=origin/latest latest
+
+  # Get user auth infor for the runner
   echo -e "Enter the runner Registry password: "
   read registryPassword
-  REGISTRY_PASSWORD=$registryPassword ./run.sh
+  echo -e "Enter the runner GitHub username: "
+  read githubUsername
+  echo -e "Enter the runner GitHub token: "
+  read githubToken
+  REGISTRY_PASSWORD=$registryPassword GITHUB_USERNAME=$githubUsername GITHUB_TOKEN=$githubToken ./run.sh
   echo -e "Runner service is up! \n"
 }
 


### PR DESCRIPTION
### Why?

> Clearly state the reason for this change. What problem is it solving or feature is it adding?

Currently, the automated deployments rely on the `runner` service to run with the self-hosted docker images (`docker.01-edu.org`). However, recently we implemented GitHub based images in the form of GitHub packages. These packages needs to be retrieved by the `runner` for running newer tests.

### Solution Overview

> Provide an overview of the solution implemented in this pull request. This should be a high level overview without getting into technical details. If applicable, include screenshots of UI or use GitHub compliant [`mermaid`](https://mermaid.live/) graphs to visually represent the solution.

Add `runner` v2 support for the configure.sh script. Which includes the deployment capabilities for the `runner` to run docker images from both GitHub and self-hosted docker images (`docker.01-edu.org`).

### Implementation Details

> Explain the details of the implementation and the reasoning behind it. What alternative approaches were considered and why was this approach chosen?

The `runner` has already been modified to accommodate these changes. The automated deployment script now takes the additional parameters during the execution to deploy the `runner` accordingly. 