### PR TITLE
DEV 4454 fix-deprecate-method-in-middle-day-rust-piscine

### DIFF
--- a/subjects/middle_day/README.md
+++ b/subjects/middle_day/README.md
@@ -18,8 +18,6 @@ Here is a program to test your function:
 use middle_day::*;
 
 fn main() {
-    let date = Utc.ymd(2011, 12, 2).and_hms(21, 12, 09);
-
     println!("{:?}", middle_day(1022).unwrap());
 }
 ```


### PR DESCRIPTION
better if `public` and `rust-tests` are merged at the same time.
[Related github issue](https://github.com/01-edu/public/issues/1802)