### PR TITLE
DEV-4390: new readmes for the exams exercises

### DIFF
--- a/subjects/atoi-exam/README.md
+++ b/subjects/atoi-exam/README.md
@@ -1,0 +1,59 @@
+## atoi
+
+### Instructions
+
+- Write a function that simulates the behaviour of the `Atoi` function in Go. `Atoi` transforms a number represented as a `string` in a number represented as an `int`.
+
+- `Atoi` returns `0` if the `string` is not considered as a valid number. For this exercise **non-valid `string` chains will be tested**. Some will contain non-digits characters.
+
+- For this exercise the handling of the signs `+` or `-` **does have** to be taken into account.
+
+- This function will **only** have to return the `int`. For this exercise the `error` result of `Atoi` is not required.
+
+### Expected function
+
+```go
+func Atoi(s string) int {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println(Atoi("12345"))
+	fmt.Println(Atoi("0000000012345"))
+	fmt.Println(Atoi("012 345"))
+	fmt.Println(Atoi("Hello World!"))
+	fmt.Println(Atoi("+1234"))
+	fmt.Println(Atoi("-1234"))
+	fmt.Println(Atoi("++1234"))
+	fmt.Println(Atoi("--1234"))
+}
+```
+
+And its output :
+
+```console
+$ go run .
+12345
+12345
+0
+0
+1234
+-1234
+0
+0
+$
+```
+
+### Notions
+
+- [strconv/Atoi](https://golang.org/pkg/strconv/#Atoi)

--- a/subjects/atoibase-exam/README.md
+++ b/subjects/atoibase-exam/README.md
@@ -1,0 +1,62 @@
+## atoibase
+
+### Instructions
+
+Write a function that takes two arguments:
+
+- `s`: a numeric `string` in a given [base](<https://simple.wikipedia.org/wiki/Base_(mathematics)>).
+- `base`: a `string` representing all the different digits that can represent a numeric value.
+
+And return the integer value of `s` in the given `base`.
+
+If the base is not valid it returns `0`.
+
+Validity rules for a base :
+
+- A base must contain at least 2 characters.
+- Each character of a base must be unique.
+- A base should not contain `+` or `-` characters.
+
+String number must contain only elements that are in base.
+
+Only valid `string` numbers will be tested.
+
+The function **does not have** to manage negative numbers.
+
+### Expected function
+
+```go
+func AtoiBase(s string, base string) int {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println(AtoiBase("125", "0123456789"))
+	fmt.Println(AtoiBase("1111101", "01"))
+	fmt.Println(AtoiBase("7D", "0123456789ABCDEF"))
+	fmt.Println(AtoiBase("uoi", "choumi"))
+	fmt.Println(AtoiBase("bbbbbab", "-ab"))
+}
+```
+
+And its output :
+
+```console
+$ go run .
+125
+125
+125
+125
+0
+$
+```

--- a/subjects/capitalize-exam/README.md
+++ b/subjects/capitalize-exam/README.md
@@ -1,0 +1,37 @@
+## capitalize
+
+### Instructions
+
+Write a function that capitalizes the first letter of each word **and** lowercases the rest.
+
+A word is a sequence of **alphanumeric** characters.
+
+### Expected function
+
+```go
+func Capitalize(s string) string {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println(Capitalize("Hello! How are you? How+are+things+4you?"))
+}
+```
+
+And its output :
+
+```console
+$ go run .
+Hello! How Are You? How+Are+Things+4you?
+$
+```

--- a/subjects/compare-exam/README.md
+++ b/subjects/compare-exam/README.md
@@ -1,0 +1,43 @@
+## compare
+
+### Instructions
+
+Write a function that behaves like the `Compare` function.
+
+### Expected function
+
+```go
+func Compare(a, b string) int {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println(Compare("Hello!", "Hello!"))
+	fmt.Println(Compare("Salut!", "lut!"))
+	fmt.Println(Compare("Ola!", "Ol"))
+}
+```
+
+And its output :
+
+```console
+$ go run .
+0
+-1
+1
+$
+```
+
+### Notions
+
+- [strings/Compare](https://golang.org/pkg/strings/#Compare)

--- a/subjects/findprevprime/README.md
+++ b/subjects/findprevprime/README.md
@@ -21,15 +21,11 @@ Here is a possible program to test your function :
 ```go
 package main
 
-import (
-	"fmt"
-
-	"piscine"
-)
+import "fmt"
 
 func main() {
-	fmt.Println(piscine.FindPrevPrime(5))
-	fmt.Println(piscine.FindPrevPrime(4))
+	fmt.Println(FindPrevPrime(5))
+	fmt.Println(FindPrevPrime(4))
 }
 ```
 

--- a/subjects/firstrune-exam/README.md
+++ b/subjects/firstrune-exam/README.md
@@ -1,0 +1,44 @@
+## firstrune
+
+### Instructions
+
+Write a function that returns the first `rune` of a `string`.
+
+### Expected function
+
+```go
+func FirstRune(s string) rune {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import (
+	"github.com/01-edu/z01"
+)
+
+func main() {
+	z01.PrintRune(FirstRune("Hello!"))
+	z01.PrintRune(FirstRune("Salut!"))
+	z01.PrintRune(FirstRune("Ola!"))
+	z01.PrintRune('\n')
+}
+```
+
+And its output :
+
+```console
+$ go run .
+HSO
+$
+```
+
+### Notions
+
+- [rune-literals](https://golang.org/ref/spec#Rune_literals)

--- a/subjects/foreach-exam/README.md
+++ b/subjects/foreach-exam/README.md
@@ -1,0 +1,48 @@
+## foreach
+
+### Instructions
+
+Write a function `ForEach` that, for an `int` slice, applies a function on each element of that slice.
+
+### Expected function
+
+```go
+func ForEach(f func(int), a []int) {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import "fmt"
+
+func PrintNbr(n int) {
+	fmt.Print(n)
+}
+
+func main() {
+
+	a := []int{1, 2, 3, 4, 5, 6}
+	ForEach(PrintNbr, a)
+    fmt.Println()
+}
+```
+
+And its output :
+
+```console
+$ go run .
+123456
+$
+```
+
+### Notions
+
+- [Function literals](https://golang.org/ref/spec#Function_literals)
+- [Function declaration](https://golang.org/ref/spec#Function_declarations)
+- [Function types](https://golang.org/ref/spec#Function_types)

--- a/subjects/lastrune-exam/README.md
+++ b/subjects/lastrune-exam/README.md
@@ -1,0 +1,44 @@
+## lastrune
+
+### Instructions
+
+Write a function that returns the last `rune` of a `string`.
+
+### Expected function
+
+```go
+func LastRune(s string) rune {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import (
+	"github.com/01-edu/z01"
+)
+
+func main() {
+	z01.PrintRune(LastRune("Hello!"))
+	z01.PrintRune(LastRune("Salut!"))
+	z01.PrintRune(LastRune("Ola!"))
+	z01.PrintRune('\n')
+}
+```
+
+And its output :
+
+```console
+$ go run .
+!!!
+$
+```
+
+### Notions
+
+- [rune-literals](https://golang.org/ref/spec#Rune_literals)

--- a/subjects/listremoveif-exam/README.md
+++ b/subjects/listremoveif-exam/README.md
@@ -1,0 +1,102 @@
+## listremoveif
+
+### Instructions
+
+Write a function `ListRemoveIf` that removes all elements that are equal to the `data_ref` in the argument of the function.
+
+### Expected function and structure
+
+```go
+type NodeL struct {
+	Data interface{}
+	Next *NodeL
+}
+
+type List struct {
+	Head *NodeL
+	Tail *NodeL
+}
+
+func ListRemoveIf(l *List, data_ref interface{}) {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import "fmt"
+
+func PrintList(l *List) {
+	it := l.Head
+	for it != nil {
+		fmt.Print(it.Data, " -> ")
+		it = it.Next
+	}
+
+	fmt.Print(nil, "\n")
+}
+
+func main() {
+	link := &List{}
+	link2 := &List{}
+
+	fmt.Println("----normal state----")
+	ListPushBack(link2, 1)
+	PrintList(link2)
+	ListRemoveIf(link2, 1)
+	fmt.Println("------answer-----")
+	PrintList(link2)
+	fmt.Println()
+
+	fmt.Println("----normal state----")
+	ListPushBack(link, 1)
+	ListPushBack(link, "Hello")
+	ListPushBack(link, 1)
+	ListPushBack(link, "There")
+	ListPushBack(link, 1)
+	ListPushBack(link, 1)
+	ListPushBack(link, "How")
+	ListPushBack(link, 1)
+	ListPushBack(link, "are")
+	ListPushBack(link, "you")
+	ListPushBack(link, 1)
+	PrintList(link)
+
+	ListRemoveIf(link, 1)
+	fmt.Println("------answer-----")
+	PrintList(link)
+}
+
+func ListPushBack(l *List, data interface{}) {
+	n := &NodeL{Data: data}
+	if l.Head == nil {
+		l.Head = n
+		l.Tail = n
+	} else {
+		l.Tail.Next = n
+		l.Tail = n
+	}
+}
+
+```
+
+And its output :
+
+```console
+$ go run .
+----normal state----
+1 -> <nil>
+------answer-----
+<nil>
+
+----normal state----
+1 -> Hello -> 1 -> There -> 1 -> 1 -> How -> 1 -> are -> you -> 1 -> <nil>
+------answer-----
+Hello -> There -> How -> are -> you -> <nil>
+$
+```

--- a/subjects/listsize-exam/README.md
+++ b/subjects/listsize-exam/README.md
@@ -1,0 +1,62 @@
+## listsize
+
+### Instructions
+
+Write a function `ListSize` that returns the number of elements in a linked list `l`.
+
+### Expected function and structure
+
+```go
+type NodeL struct {
+	Data interface{}
+	Next *NodeL
+}
+
+type List struct {
+	Head *NodeL
+	Tail *NodeL
+}
+
+func ListSize(l *List) int {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import "fmt"
+
+func ListPushFront(l *List, data interface{}) {
+	n := &NodeL{Data: data}
+	if l.Head == nil {
+		l.Head = n
+		l.Tail = n
+	} else {
+		l.Head, n.Next = n, l.Head
+	}
+}
+
+func main() {
+	link := &List{}
+
+	ListPushFront(link, "Hello")
+	ListPushFront(link, "2")
+	ListPushFront(link, "you")
+	ListPushFront(link, "man")
+
+	fmt.Println(ListSize(link))
+}
+```
+
+And its output :
+
+```console
+$ go run .
+4
+$
+```

--- a/subjects/max-exam/README.md
+++ b/subjects/max-exam/README.md
@@ -1,0 +1,37 @@
+## max
+
+### Instructions
+
+Write a function `Max` that will return the maximum value in a slice of integers. If the slice is empty it will return 0.
+
+### Expected function
+
+```go
+func Max(a []int) int {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	a := []int{23, 123, 1, 11, 55, 93}
+	max := Max(a)
+	fmt.Println(max)
+}
+```
+
+And its output :
+
+```console
+$ go run .
+123
+$
+```

--- a/subjects/nrune-exam/README.md
+++ b/subjects/nrune-exam/README.md
@@ -1,0 +1,46 @@
+## nrune
+
+### Instructions
+
+Write a function that returns the nth `rune` of a `string`. If not possible, it returns `0`.
+
+### Expected function
+
+```go
+func NRune(s string, n int) rune {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import (
+	"github.com/01-edu/z01"
+)
+
+func main() {
+	z01.PrintRune(NRune("Hello!", 3))
+	z01.PrintRune(NRune("Salut!", 2))
+	z01.PrintRune(NRune("Bye!", -1))
+	z01.PrintRune(NRune("Bye!", 5))
+	z01.PrintRune(NRune("Ola!", 4))
+	z01.PrintRune('\n')
+}
+```
+
+And its output :
+
+```console
+$ go run .
+la!
+$
+```
+
+### Notions
+
+- [rune-literals](https://golang.org/ref/spec#Rune_literals)

--- a/subjects/printcomb-exam/README.md
+++ b/subjects/printcomb-exam/README.md
@@ -1,0 +1,43 @@
+## printcomb
+
+### Instructions
+
+Write a function that prints, in ascending order and on a single line: all **unique** combinations of three different digits so that, the first digit is lower than the second, and the second is lower than the third.
+
+These combinations are separated by a comma and a space.
+
+### Expected function
+
+```go
+func PrintComb() {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+func main() {
+	PrintComb()
+}
+```
+
+This is the incomplete output :
+
+```console
+$ go run . | cat -e
+012, 013, 014, 015, 016, 017, 018, 019, 023, ..., 689, 789$
+$
+```
+
+- `000` or `999` are not valid combinations because the digits are not different.
+
+- `987` should not be shown because the first digit is not less than the second.
+
+### Notions
+
+- [01-edu/z01](https://github.com/01-edu/z01)

--- a/subjects/printstr-exam/README.md
+++ b/subjects/printstr-exam/README.md
@@ -1,0 +1,36 @@
+## printstr
+
+### Instructions
+
+- Write a function that prints one by one the characters of a `string` on the screen.
+
+### Expected function
+
+```go
+func PrintStr(s string) {
+
+}
+```
+
+### Hints
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+func main() {
+	PrintStr("Hello World!")
+}
+```
+
+And its output :
+
+```console
+go run . | cat -e
+Hello World!
+```
+
+### Notions
+
+- [01-edu/z01](https://github.com/01-edu/z01)

--- a/subjects/rot14-exam/README.md
+++ b/subjects/rot14-exam/README.md
@@ -1,0 +1,45 @@
+## rot14
+
+### Instructions
+
+Write a function `rot14` that returns the `string` within the parameter transformed into a `rot14 string`.
+Each letter will be replaced by the letter 14 spots ahead in the alphabetical order.
+
+- 'z' becomes 'n' and 'Z' becomes 'N'. The case of the letter stays the same.
+
+### Expected function
+
+```go
+func Rot14(s string) string {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import (
+	"github.com/01-edu/z01"
+)
+
+func main() {
+	result := Rot14("Hello! How are You?")
+
+	for _, r := range result {
+		z01.PrintRune(r)
+	}
+	z01.PrintRune('\n')
+}
+```
+
+And its output :
+
+```console
+$ go run .
+Vszzc! Vck ofs Mci?
+$
+```

--- a/subjects/slice/README.md
+++ b/subjects/slice/README.md
@@ -23,19 +23,15 @@ Here is a possible program to test your function :
 ```go
 package main
 
-import (
-	"fmt"
-
-	"piscine"
-)
+import "fmt"
 
 func main(){
     a := []string{"coding", "algorithm", "ascii", "package", "golang"}
-    fmt.Printf("%#v\n", piscine.Slice(a, 1))
-    fmt.Printf("%#v\n", piscine.Slice(a, 2, 4))
-    fmt.Printf("%#v\n", piscine.Slice(a, -3))
-    fmt.Printf("%#v\n", piscine.Slice(a, -2, -1))
-    fmt.Printf("%#v\n", piscine.Slice(a, 2, 0))
+    fmt.Printf("%#v\n", Slice(a, 1))
+    fmt.Printf("%#v\n", Slice(a, 2, 4))
+    fmt.Printf("%#v\n", Slice(a, -3))
+    fmt.Printf("%#v\n", Slice(a, -2, -1))
+    fmt.Printf("%#v\n", Slice(a, 2, 0))
 }
 ```
 

--- a/subjects/sortwordarr-exam/README.md
+++ b/subjects/sortwordarr-exam/README.md
@@ -1,0 +1,38 @@
+## sortwordarr
+
+### Instructions
+
+Write a function `SortWordArr` that sorts by `ascii` (in ascending order) a `string` slice.
+
+### Expected function
+
+```go
+func SortWordArr(a []string) {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	result := []string{"a", "A", "1", "b", "B", "2", "c", "C", "3"}
+	SortWordArr(result)
+
+	fmt.Println(result)
+}
+```
+
+And its output :
+
+```console
+$ go run .
+[1 2 3 A B C a b c]
+$
+```

--- a/subjects/split-exam/README.md
+++ b/subjects/split-exam/README.md
@@ -1,0 +1,36 @@
+## split
+
+### Instructions
+
+Write a function that receives a string and a separator and returns a `slice of strings` that results of splitting the string `s` by the separator `sep`.
+
+### Expected function
+
+```go
+func Split(s, sep string) []string {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	s := "HelloHAhowHAareHAyou?"
+	fmt.Printf("%#v\n", Split(s, "HA"))
+}
+```
+
+And its output :
+
+```console
+$ go run .
+[]string{"Hello", "how", "are", "you?"}
+$
+```

--- a/subjects/strlen-exam/README.md
+++ b/subjects/strlen-exam/README.md
@@ -1,0 +1,36 @@
+## strlen
+
+### Instructions
+
+- Write a function that counts the `runes` of a `string` and that returns that count.
+
+### Expected function
+
+```go
+func StrLen(s string) int {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	l := StrLen("Hello World!")
+	fmt.Println(l)
+}
+```
+
+And its output :
+
+```console
+$ go run .
+12
+$
+```

--- a/subjects/strrev-exam/README.md
+++ b/subjects/strrev-exam/README.md
@@ -1,0 +1,39 @@
+## strrev
+
+### Instructions
+
+- Write a function that reverses a `string`.
+
+- This function will **return** the reversed `string`.
+
+### Expected function
+
+```go
+func StrRev(s string) string {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	s := "Hello World!"
+	s = StrRev(s)
+	fmt.Println(s)
+}
+```
+
+And its output :
+
+```console
+$ go run .
+!dlroW olleH
+$
+```

--- a/subjects/swap-exam/README.md
+++ b/subjects/swap-exam/README.md
@@ -1,0 +1,44 @@
+## swap
+
+### Instructions
+
+- Write a function that takes two **pointers to an `int`** (`*int`) and swaps their contents.
+
+### Expected function
+
+```go
+func Swap(a *int, b *int) {
+
+}
+```
+
+### Usage
+
+Here is a possible program to test your function :
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	a := 0
+	b := 1
+	Swap(&a, &b)
+	fmt.Println(a)
+	fmt.Println(b)
+}
+```
+
+And its output :
+
+```console
+$ go run .
+1
+0
+$
+```
+
+### Notions
+
+- [Pointers](https://golang.org/ref/spec#Pointer_types)


### PR DESCRIPTION
DEV-4390

### Why?

>  Some of the exercises are using the import "piscine" and they need to be removed on the exams.

### Solution Overview

>  For now, the fix was to create duplicated subjects and new refs for the exercises in the exam, but in the future they will to be removed