### PR TITLE
fix return type of function

### DIFF
--- a/subjects/hashing/README.md
+++ b/subjects/hashing/README.md
@@ -4,7 +4,7 @@
 
 Given a list of integers (`Vec<i32>`) write three **functions**.
 
--`mean`: that calculates the mean (the average value) of all the values in the list.
+- `mean`: that calculates the mean (the average value) of all the values in the list.
 
 - `median`: that calculates the median (for a sorted list, it is the value in the middle). If there is an even amount of numbers in the list, the middle pair must be determined, added together, and divided by two to find the median value.
 

--- a/subjects/partial_sums/README.md
+++ b/subjects/partial_sums/README.md
@@ -40,7 +40,7 @@ parts_sums(&[1, 2, 3, 4, 5]) // == [15, 10, 6, 3 ,1, 0]
 ### Expected Result
 
 ```rs
-pub fn parts_sums(arr: &[u64]) -> Vec<64>{
+pub fn parts_sums(arr: &[u64]) -> Vec<u64>{
 }
 ```
 


### PR DESCRIPTION

### Why?

This corrects a typing error, as 64 is not a valid type in Rust.
