### PR TITLE
DEV-4509-make-subjects-pretty

### DIFF
--- a/subjects/blockchain/artists-do-work/README.md
+++ b/subjects/blockchain/artists-do-work/README.md
@@ -1,4 +1,4 @@
-# Artists Do Work
+## Artists Do Work
 
 Artists deserve to be payed too! Along the way, we will learn payments and divisions in Solidity
 

--- a/subjects/blockchain/basic-swap/README.md
+++ b/subjects/blockchain/basic-swap/README.md
@@ -1,4 +1,4 @@
-# Basic Swap
+## Basic Swap
 
 We will create a basic swap smart contract that will allow two users, Alice and Bob, to exchange two minimal tokens safely. The contracts will be specific to the two users and unidirectional.
 

--- a/subjects/blockchain/basic-wallet/README.md
+++ b/subjects/blockchain/basic-wallet/README.md
@@ -1,4 +1,4 @@
-# Basic Wallet
+## Basic Wallet
 
 _- Do you always look at it encoded ?_
 _- Well you have to, the image translators work for the construct program, but there is way too much information to decode the Matrix_
@@ -19,14 +19,14 @@ _- Well you have to, the image translators work for the construct program, but t
 ### Usage
 
 ```js
-let address = generateAddress();
-console.log(address);
+let address = generateAddress()
+console.log(address)
 // 01ae9596973b45d10e6a65c7fdcc593f63283bd405539c77e83938750d29729fac
 let transaction = createTransaction(
   200,
-  "01ffa17f4e0bbb2f049f5d1f9d4ab9fad967e6b0ed9a8fc94563d0b4e47b62e169"
-);
-console.log(transaction);
+  '01ffa17f4e0bbb2f049f5d1f9d4ab9fad967e6b0ed9a8fc94563d0b4e47b62e169',
+)
+console.log(transaction)
 // 01ae9596973b45d10e6a65c7fdcc593f63283bd405539c77e83938750d29729fac01ffa17f4e0bbb2f049f5d1f9d4ab9fad967e6b0ed9a8fc94563d0b4e47b62e1692003045022017cdeb0e982e0705044caeb73db8d86992282f466c8b124cff0bfef64ae8be72022100ec4c6025d83a726bb483ebd05e53da37de28eaeb5db85068e355974c3caffaa4
 ```
 

--- a/subjects/blockchain/buy-tickets/README.md
+++ b/subjects/blockchain/buy-tickets/README.md
@@ -1,4 +1,4 @@
-# Festival Buy Ticket
+## Festival Buy Ticket
 
 A core functionality of your smart contract is the ability to sell tickets. You will sell them for 0.1 Ethers. An Ethereum address could own several tickets.
 

--- a/subjects/blockchain/check-document/README.md
+++ b/subjects/blockchain/check-document/README.md
@@ -1,4 +1,4 @@
-# Check Document
+## Check Document
 
 ### Instructions
 
@@ -12,16 +12,16 @@ Write a node script that exports the function `checkDocument()` that :
 function checkDocument(text, txID) {
   //...
 }
-module.exports = checkDocument;
+module.exports = checkDocument
 ```
 
 ### Usage
 
 ```js
 checkDocument(
-  "Hello world!",
-  "0x49c8803ea126179502d59707dbcd9e9de15f5d441920936e9ec6fd78dd6468d8"
-);
+  'Hello world!',
+  '0x49c8803ea126179502d59707dbcd9e9de15f5d441920936e9ec6fd78dd6468d8',
+)
 // Expected :
 //1611104541
 ```

--- a/subjects/blockchain/connect-to-metamask/README.md
+++ b/subjects/blockchain/connect-to-metamask/README.md
@@ -1,4 +1,4 @@
-# Connect To MetaMask
+## Connect To MetaMask
 
 ### Instructions
 

--- a/subjects/blockchain/decentralized-finance/README.md
+++ b/subjects/blockchain/decentralized-finance/README.md
@@ -1,4 +1,4 @@
-# Decentralized Finance
+## Decentralized Finance
 
 _I accidentally killed it - devops199_
 
@@ -20,7 +20,7 @@ First, we will create a simple stablecoin, following the ERC20 standard and an o
 
 ---
 
-# Exercise 1: Stablecoin
+## Exercise 1: Stablecoin
 
 The purpose of this exercise is to create a fully collateralized stablecoin. We will use an oracle smart contract to get the current value of any volatile token.
 
@@ -54,7 +54,7 @@ And, the keystone, we allow any user to punish users that issued more tokens tha
 
 ---
 
-# Exercise 2: Lending Platform
+## Exercise 2: Lending Platform
 
 We will create a platforms that allow borrowers tokens from lenders in a decentralized manner around a volatile and a stable token. Lenders will earn a fixed yield of 5% per year.
 
@@ -92,7 +92,7 @@ _Optional provide a web interface for the lending platform_
 
 ---
 
-# Exercise 3: Tests and Coverage
+## Exercise 3: Tests and Coverage
 
 To produce adequate tests is the first obvious step to start applying good security measures. We will create the tests for the stablecoin smart contract.
 

--- a/subjects/blockchain/decentralized-finance/README.md
+++ b/subjects/blockchain/decentralized-finance/README.md
@@ -20,7 +20,7 @@ First, we will create a simple stablecoin, following the ERC20 standard and an o
 
 ---
 
-## Exercise 1: Stablecoin
+### Exercise 1: Stablecoin
 
 The purpose of this exercise is to create a fully collateralized stablecoin. We will use an oracle smart contract to get the current value of any volatile token.
 
@@ -54,7 +54,7 @@ And, the keystone, we allow any user to punish users that issued more tokens tha
 
 ---
 
-## Exercise 2: Lending Platform
+### Exercise 2: Lending Platform
 
 We will create a platforms that allow borrowers tokens from lenders in a decentralized manner around a volatile and a stable token. Lenders will earn a fixed yield of 5% per year.
 
@@ -92,7 +92,7 @@ _Optional provide a web interface for the lending platform_
 
 ---
 
-## Exercise 3: Tests and Coverage
+### Exercise 3: Tests and Coverage
 
 To produce adequate tests is the first obvious step to start applying good security measures. We will create the tests for the stablecoin smart contract.
 

--- a/subjects/blockchain/donation/README.md
+++ b/subjects/blockchain/donation/README.md
@@ -1,4 +1,4 @@
-# Donation
+## Donation
 
 We will use a new wallet to send t donation
 

--- a/subjects/blockchain/eventful-token/README.md
+++ b/subjects/blockchain/eventful-token/README.md
@@ -1,4 +1,4 @@
-# Eventful Token
+## Eventful Token
 
 ### Instructions
 

--- a/subjects/blockchain/exploring-blockchains/README.md
+++ b/subjects/blockchain/exploring-blockchains/README.md
@@ -1,4 +1,4 @@
-# Exploring Blockchains
+## Exploring Blockchains
 
 _If you don't believe it or don't get it, I don't have the time to try to convince you, sorry. — Satoshi Nakamoto_
 
@@ -19,7 +19,7 @@ In this course, we will focus on two solutions provided by the Hyperledger proje
 
 ---
 
-# Exercise 1: Private Network
+## Exercise 1: Private Network
 
 Besu in an alternative Ethereum client that is compatible with Ethereum mainnet. It facilitates the deployment of private networks. Will we use the QBFT consensus algorithm, a Proof of Authority Byzantine Fault Tolerant algorithm
 
@@ -64,7 +64,7 @@ Network/
 
 ---
 
-# Exercise 2: Clillet
+## Exercise 2: Clillet
 
 The goal of this raid is to create a fully functional command line wallet for a blockchain of your choice. You can choose any of the major alternative blockchains: Solana, Tezos, Poladot, Cosmos... The executable `clillet` must follow and implement the help description below. Our wallet consists of the following subcommands
 

--- a/subjects/blockchain/exploring-blockchains/README.md
+++ b/subjects/blockchain/exploring-blockchains/README.md
@@ -19,7 +19,7 @@ In this course, we will focus on two solutions provided by the Hyperledger proje
 
 ---
 
-## Exercise 1: Private Network
+### Exercise 1: Private Network
 
 Besu in an alternative Ethereum client that is compatible with Ethereum mainnet. It facilitates the deployment of private networks. Will we use the QBFT consensus algorithm, a Proof of Authority Byzantine Fault Tolerant algorithm
 
@@ -54,7 +54,15 @@ Network/
 ├ keys.json
 ```
 
+<<<<<<< HEAD
+
 ## Resources
+
+=======
+
+### Resources
+
+> > > > > > > cfdf326c (fix(blockchain subjects):)
 
 - [Private network explanation](https://ethereum.org/en/developers/docs/networks/#private-networks)
 - [Launch a private network with Besu tutorial](https://besu.hyperledger.org/en/stable/Tutorials/Private-Network/Create-QBFT-Network/)
@@ -64,7 +72,7 @@ Network/
 
 ---
 
-## Exercise 2: Clillet
+### Exercise 2: Clillet
 
 The goal of this raid is to create a fully functional command line wallet for a blockchain of your choice. You can choose any of the major alternative blockchains: Solana, Tezos, Poladot, Cosmos... The executable `clillet` must follow and implement the help description below. Our wallet consists of the following subcommands
 
@@ -76,7 +84,7 @@ The goal of this raid is to create a fully functional command line wallet for a 
 
 The documentation must provide an endpoint to connect to a blockchain node of the testnet network with necessary information to create an account to access this endpoint if needed and to retrieve tokens from a faucet.
 
-## Output and functionalities
+### Output and functionalities
 
 ```console
 $ clillet --help
@@ -98,7 +106,6 @@ FLAGS:
     -V, --version
             Prints version information
 
-
 COMMANDS:
    generate                      Generates a new wallet and prints the mnemonic
    import <file>                 Imports a wallet from a file
@@ -108,7 +115,7 @@ COMMANDS:
    send <destination> <amount>   sends assets to a destination
 ```
 
-## Deliverable
+### Deliverable
 
 The project must provide an executable file that complies with the specifications
 

--- a/subjects/blockchain/financial-instruments/README.md
+++ b/subjects/blockchain/financial-instruments/README.md
@@ -8,11 +8,11 @@ In that context, we will build a financial instruments platform. First, we will 
 
 In this project, you are free to use the blockchain, technologies, and tools that you want. However, the project must offer complete documentation.
 
-## Private network
+### Private network
 
 The network must have a minimum of 3 validating nodes. A script must facilitate the deployment of the network. You can reuse prior work.
 
-## Financial instruments
+### Financial instruments
 
 Three categories of financial instruments can be exchanged on the platform. Functionally, each asset is a type of smart contract
 
@@ -20,7 +20,7 @@ Three categories of financial instruments can be exchanged on the platform. Func
 - **Shares**: Shares are a fungible token for each company. Occasionally, its issuer can do a dividend payout. In that case, the issuer sends the stablecoin to the share contract, and each owner can retrieve proportionally to its possessions.
 - **Bonds: **A smart contract represents all the outstanding bonds from an issuer. Each bond has a unique serial number, a current principal, an interest rate, an issuance date, a maturity date, a current owner, and if it has been repaid. For simplicity, we assume each bond to be issued for one year, requiring only one payment.
 
-## Populating
+### Populating
 
 In order to facilitate tests and audits, we will populate those financial instruments. An interactive script is available to create several addresses and deploy smart contracts.
 
@@ -35,7 +35,7 @@ Additionally, the script asks for two Ethereum addresses, Aya and Beatriz.
 - Aya should receive 200 TRG, 10 CLV and 2 GOV.
 - Beatriz should receive 150 TRV, 20 ROO and 5 GOV.
 
-## Marketplace
+### Marketplace
 
 The marketplace consists of
 
@@ -45,7 +45,7 @@ The marketplace consists of
 
 Our model is hybrid, as order execution is centralised, but assets are not in full custody of the platform.
 
-## Web interface
+### Web interface
 
 The interface must consist of a homepage, an asset page, a portfolio page, and an FAQ page.
 
@@ -139,7 +139,7 @@ A visualization part allows the user to have a sense of his possession in TRG. F
 
 An FAQ page that explains how to use the platform
 
-## The server
+#### The server
 
 The server serves the fronted using the database information, exposes an API for the frontend and interacts with the blockchain. Its API must offer a function to monitor deposits, triggered from the user interface, that verifies on the blockchain the transaction that sent the funds and another one to authorise withdrawals.
 
@@ -149,23 +149,23 @@ The database contains
 - A table of the users of the platform registered after the first connection. They must provide their legal name and upload a “passport” picture. No check is made when login in, but the picture is stored for future reference
 - A table of all ongoing sell and buy offers on the platform
 
-## The vault smart contract
+#### The vault smart contract
 
 The vault smart contract will receive the various financial assets. In a simple form, it includes an `operateWithdrawal(user, asset, amount)` reserved to the platform issuer allows the platform to send assets to the user, after verifying that the funds were theirs and that there are no pending orders.
 
 _Optionally, a more sophisticated security model can be proposed._
 
-## Trade execution
+#### Trade execution
 
 If a user, Aya, wants to sell CLV shares, she will go to the dedicated CLV page. On the panel on the right, she will select a number of shares, for instance 5, among her total number of shares, and a price, for instance, 9. The shares will then be transferred to the smart contract of the platform. Her address however will be approved to retrieve. When a user, Beatriz, wants to buy 3 CLV shares at the current market price, he selects this option on the panel. The platform will select the best offers. In this example, it will retain the 3 shares of Aya as available. Then, the platform will update the balance of both users in its database.
 
 The platform must handle all the cases where various offers must be used to fulfil a demand.
 
-## Withdrawal
+### Withdrawal
 
 At any point, the users can ask to withdraw their funds. On their portfolio page, users can click on assets that are on the platform. The platform server verifies that the assets are not part of any pending offer and send an `operateWithdrawal()` to the vault smart contract. Once validated, the frontend updates the user information.
 
-## Documentation
+### Documentation
 
 In addition to the FAQ on the website explaining functionality as mentioned in the interface section, we need a full developer documentation. It must explain
 

--- a/subjects/blockchain/financial-instruments/README.md
+++ b/subjects/blockchain/financial-instruments/README.md
@@ -1,4 +1,4 @@
-# An international settlement platform
+## An international settlement platform
 
 _"Computer science education cannot make anybody an expert programmer any more than studying brushes and pigment can make somebody an expert painter." - Eric S. Raymond_
 
@@ -6,7 +6,7 @@ One of the key elements of blockchains' value proposition is providing the techn
 
 In that context, we will build a financial instruments platform. First, we will represent a stablecoin, shares and bonds on a private blockchain network. Then a marketplace website will allow users to list, buy and sell assets.
 
-In this project, you are free to use the blockchain, technologies, and tools that you want. However, the project must offer complete documentation. 
+In this project, you are free to use the blockchain, technologies, and tools that you want. However, the project must offer complete documentation.
 
 ## Private network
 
@@ -16,56 +16,56 @@ The network must have a minimum of 3 validating nodes. A script must facilitate 
 
 Three categories of financial instruments can be exchanged on the platform. Functionally, each asset is a type of smart contract
 
-* **Stablecoins**: It must be a standard fungible token (ERC20 or equivalent). It initially has 1000 units. The creator of the stablecoin can issue or remove units.
-* **Shares**: Shares are a fungible token for each company. Occasionally, its issuer can do a dividend payout. In that case, the issuer sends the stablecoin to the share contract, and each owner can retrieve proportionally to its possessions. 
-* **Bonds: **A smart contract represents all the outstanding bonds from an issuer. Each bond has a unique serial number, a current principal, an interest rate, an issuance date, a maturity date, a current owner, and if it has been repaid. For simplicity, we assume each bond to be issued for one year, requiring only one payment. 
+- **Stablecoins**: It must be a standard fungible token (ERC20 or equivalent). It initially has 1000 units. The creator of the stablecoin can issue or remove units.
+- **Shares**: Shares are a fungible token for each company. Occasionally, its issuer can do a dividend payout. In that case, the issuer sends the stablecoin to the share contract, and each owner can retrieve proportionally to its possessions.
+- **Bonds: **A smart contract represents all the outstanding bonds from an issuer. Each bond has a unique serial number, a current principal, an interest rate, an issuance date, a maturity date, a current owner, and if it has been repaid. For simplicity, we assume each bond to be issued for one year, requiring only one payment.
 
 ## Populating
 
-In order to facilitate tests and audits, we will populate those financial instruments. An interactive script is available to create several addresses and deploy smart contracts. 
+In order to facilitate tests and audits, we will populate those financial instruments. An interactive script is available to create several addresses and deploy smart contracts.
 
-* A stablecoin called “triangle” with the ticker “TRG” and 4000 units available.
-* Shares from “Clove Company” represented as “CLV” and “Rooibos Limited” “ROO”, with 100 shares each.
-* Government bonds, “GOV”, for a principal of 200 each and an interest rate of 10%, 20 units.
+- A stablecoin called “triangle” with the ticker “TRG” and 4000 units available.
+- Shares from “Clove Company” represented as “CLV” and “Rooibos Limited” “ROO”, with 100 shares each.
+- Government bonds, “GOV”, for a principal of 200 each and an interest rate of 10%, 20 units.
 
 Each instrument is issued by a distinct address that owns all units initially.
 
 Additionally, the script asks for two Ethereum addresses, Aya and Beatriz.
-- Aya should receive 200 TRG, 10 CLV and 2 GOV. 
-- Beatriz should receive 150 TRV, 20 ROO and 5 GOV.
 
+- Aya should receive 200 TRG, 10 CLV and 2 GOV.
+- Beatriz should receive 150 TRV, 20 ROO and 5 GOV.
 
 ## Marketplace
 
-The marketplace consists of 
+The marketplace consists of
 
+- A web interface that allows users to visualise information and give orders.
+- A server with an API and a database that stores listed assets and orders.
+- A multi-signature vault smart contract that contains customer assets.
 
-
-* A web interface that allows users to visualise information and give orders.
-* A server with an API and a database that stores listed assets and orders. 
-* A multi-signature vault smart contract that contains customer assets. 
-
-Our model is hybrid, as order execution is centralised, but assets are not in full custody of the platform. 
-
+Our model is hybrid, as order execution is centralised, but assets are not in full custody of the platform.
 
 ## Web interface
 
 The interface must consist of a homepage, an asset page, a portfolio page, and an FAQ page.
 
 ### Homepage
+
 An introduction page to the platform that allows the user to connect a wallet
 
 ### Asset pages
+
 A page per asset (only share and bonds) that provides on the left a curve with the price of prior trades and on the right control buttons
-    * The price by default is 10 TRG for a CLV and a ROO share and 200 TRG for GOV bonds. The curve is a straight line until trades are made.
-    * Command buttons allow users to 
-        * Create a sell order for this asset or a buy order for this asset with an input field allowing them to select the number of units and establish a price. 
-        * To buy or sell a certain asset at the current market price.
+_ The price by default is 10 TRG for a CLV and a ROO share and 200 TRG for GOV bonds. The curve is a straight line until trades are made.
+_ Command buttons allow users to
+_ Create a sell order for this asset or a buy order for this asset with an input field allowing them to select the number of units and establish a price.
+_ To buy or sell a certain asset at the current market price.
 
 ### Portfolio page
+
 A portfolio page that shows to the user his possessions.
 
-A table shows in one column the number of units available in total for each asset and another column with the amount currently stored on the platform with a button to withdraw it. Each asset name should redirect to the dedicated page. 
+A table shows in one column the number of units available in total for each asset and another column with the amount currently stored on the platform with a button to withdraw it. Each asset name should redirect to the dedicated page.
 
 <table>
   <tr>
@@ -131,52 +131,48 @@ Total available</p>
   </tr>
 </table>
 
-A visualization part allows the user to have a sense of his possession in TRG. For instance, a pie chart proportional to the current price of each asset can be displayed. For instance, assuming the default prices, the table above should render this way. 
+A visualization part allows the user to have a sense of his possession in TRG. For instance, a pie chart proportional to the current price of each asset can be displayed. For instance, assuming the default prices, the table above should render this way.
 
-  ![alt_text](viz.png "Vizualisation")
+![alt_text](viz.png 'Vizualisation')
 
 ### FAQ page
-An FAQ page that explains how to use the platform 
 
+An FAQ page that explains how to use the platform
 
 ## The server
 
 The server serves the fronted using the database information, exposes an API for the frontend and interacts with the blockchain. Its API must offer a function to monitor deposits, triggered from the user interface, that verifies on the blockchain the transaction that sent the funds and another one to authorise withdrawals.
 
 The database contains
-* A table with the assets usable on the platform, their type, the address of their smart contract, and their price history.
-* A table of the users of the platform registered after the first connection. They must provide their legal name and upload a “passport” picture. No check is made when login in, but the picture is stored for future reference
-* A table of all ongoing sell and buy offers on the platform
 
+- A table with the assets usable on the platform, their type, the address of their smart contract, and their price history.
+- A table of the users of the platform registered after the first connection. They must provide their legal name and upload a “passport” picture. No check is made when login in, but the picture is stored for future reference
+- A table of all ongoing sell and buy offers on the platform
 
 ## The vault smart contract
 
-The vault smart contract will receive the various financial assets. In a simple form, it includes an `operateWithdrawal(user, asset, amount)` reserved to the platform issuer allows the platform to send assets to the user, after verifying that the funds were theirs and that there are no pending orders. 
+The vault smart contract will receive the various financial assets. In a simple form, it includes an `operateWithdrawal(user, asset, amount)` reserved to the platform issuer allows the platform to send assets to the user, after verifying that the funds were theirs and that there are no pending orders.
 
 _Optionally, a more sophisticated security model can be proposed._
 
-
 ## Trade execution
 
-If a user, Aya, wants to sell CLV shares, she will go to the dedicated CLV page. On the panel on the right, she will select a number of shares, for instance 5, among her total number of shares, and a price, for instance, 9. The shares will then be transferred to the smart contract of the platform. Her address however will be approved to retrieve. When a user, Beatriz, wants to buy 3 CLV shares at the current market price, he selects this option on the panel. The platform will select the best offers. In this example, it will retain the 3 shares of Aya as available. Then, the platform will update the balance of both users in its database. 
+If a user, Aya, wants to sell CLV shares, she will go to the dedicated CLV page. On the panel on the right, she will select a number of shares, for instance 5, among her total number of shares, and a price, for instance, 9. The shares will then be transferred to the smart contract of the platform. Her address however will be approved to retrieve. When a user, Beatriz, wants to buy 3 CLV shares at the current market price, he selects this option on the panel. The platform will select the best offers. In this example, it will retain the 3 shares of Aya as available. Then, the platform will update the balance of both users in its database.
 
-The platform must handle all the cases where various offers must be used to fulfil a demand. 
-
+The platform must handle all the cases where various offers must be used to fulfil a demand.
 
 ## Withdrawal
 
-At any point, the users can ask to withdraw their funds. On their portfolio page, users can click on assets that are on the platform. The platform server verifies that the assets are not part of any pending offer and send an `operateWithdrawal()` to the vault smart contract. Once validated, the frontend updates the user information. 
-
+At any point, the users can ask to withdraw their funds. On their portfolio page, users can click on assets that are on the platform. The platform server verifies that the assets are not part of any pending offer and send an `operateWithdrawal()` to the vault smart contract. Once validated, the frontend updates the user information.
 
 ## Documentation
 
-In addition to the FAQ on the website explaining functionality as mentioned in the interface section, we need a full developer documentation. It must explain 
+In addition to the FAQ on the website explaining functionality as mentioned in the interface section, we need a full developer documentation. It must explain
 
-* How to launch and deploy the platform. It must contain a step-by-step guide to install dependencies and launch the project. 
-* Describe how to launch the populating script (see section populating)
-* Describe the architecture of the project
-* Specify each API function exposed from the server
-* Describe in detail each smart contact function of the smart contract vault. 
+- How to launch and deploy the platform. It must contain a step-by-step guide to install dependencies and launch the project.
+- Describe how to launch the populating script (see section populating)
+- Describe the architecture of the project
+- Specify each API function exposed from the server
+- Describe in detail each smart contact function of the smart contract vault.
 
-The README file at the root of the project must specify where to find this documentation. 
-
+The README file at the root of the project must specify where to find this documentation.

--- a/subjects/blockchain/financial-instruments/README.md
+++ b/subjects/blockchain/financial-instruments/README.md
@@ -18,7 +18,7 @@ Three categories of financial instruments can be exchanged on the platform. Func
 
 - **Stablecoins**: It must be a standard fungible token (ERC20 or equivalent). It initially has 1000 units. The creator of the stablecoin can issue or remove units.
 - **Shares**: Shares are a fungible token for each company. Occasionally, its issuer can do a dividend payout. In that case, the issuer sends the stablecoin to the share contract, and each owner can retrieve proportionally to its possessions.
-- **Bonds: **A smart contract represents all the outstanding bonds from an issuer. Each bond has a unique serial number, a current principal, an interest rate, an issuance date, a maturity date, a current owner, and if it has been repaid. For simplicity, we assume each bond to be issued for one year, requiring only one payment.
+- **Bonds**: A smart contract represents all the outstanding bonds from an issuer. Each bond has a unique serial number, a current principal, an interest rate, an issuance date, a maturity date, a current owner, and if it has been repaid. For simplicity, we assume each bond to be issued for one year, requiring only one payment.
 
 ### Populating
 
@@ -139,7 +139,7 @@ A visualization part allows the user to have a sense of his possession in TRG. F
 
 An FAQ page that explains how to use the platform
 
-#### The server
+### The server
 
 The server serves the fronted using the database information, exposes an API for the frontend and interacts with the blockchain. Its API must offer a function to monitor deposits, triggered from the user interface, that verifies on the blockchain the transaction that sent the funds and another one to authorise withdrawals.
 
@@ -149,13 +149,13 @@ The database contains
 - A table of the users of the platform registered after the first connection. They must provide their legal name and upload a “passport” picture. No check is made when login in, but the picture is stored for future reference
 - A table of all ongoing sell and buy offers on the platform
 
-#### The vault smart contract
+### The vault smart contract
 
 The vault smart contract will receive the various financial assets. In a simple form, it includes an `operateWithdrawal(user, asset, amount)` reserved to the platform issuer allows the platform to send assets to the user, after verifying that the funds were theirs and that there are no pending orders.
 
 _Optionally, a more sophisticated security model can be proposed._
 
-#### Trade execution
+### Trade execution
 
 If a user, Aya, wants to sell CLV shares, she will go to the dedicated CLV page. On the panel on the right, she will select a number of shares, for instance 5, among her total number of shares, and a price, for instance, 9. The shares will then be transferred to the smart contract of the platform. Her address however will be approved to retrieve. When a user, Beatriz, wants to buy 3 CLV shares at the current market price, he selects this option on the panel. The platform will select the best offers. In this example, it will retain the 3 shares of Aya as available. Then, the platform will update the balance of both users in its database.
 

--- a/subjects/blockchain/financial-instruments/audit/README.md
+++ b/subjects/blockchain/financial-instruments/audit/README.md
@@ -34,7 +34,7 @@
 
 ##### As the first user, Aya, opens the CLV page and offers to sell 10 CLV at 9 TRG
 
-###### Does the interface reflect the amount of CLV available to Aya? 
+###### Does the interface reflect the amount of CLV available to Aya?
 
 ###### Does the order validation trigger a transfer of funds?
 

--- a/subjects/blockchain/fun-and-profit/README.md
+++ b/subjects/blockchain/fun-and-profit/README.md
@@ -1,4 +1,4 @@
-# Fun and Profit
+## Fun and Profit
 
 The Festival is going well. Attendees are entering by redeeming tickets and enjoying it. It is now time for the organizer to cash out the benefits.
 

--- a/subjects/blockchain/generate-address/README.md
+++ b/subjects/blockchain/generate-address/README.md
@@ -1,4 +1,4 @@
-# Generate Address
+## Generate Address
 
 ### Instructions
 

--- a/subjects/blockchain/get-account/README.md
+++ b/subjects/blockchain/get-account/README.md
@@ -1,4 +1,4 @@
-# Get Account
+## Get Account
 
 Now you will interact with the node's API
 
@@ -14,7 +14,7 @@ For this exercise you will have to create a node script that :
 function getAccount() {
   //...
 }
-module.exports = getAccount;
+module.exports = getAccount
 ```
 
 ### Notions

--- a/subjects/blockchain/hash-160/README.md
+++ b/subjects/blockchain/hash-160/README.md
@@ -1,4 +1,4 @@
-# Hash160
+## Hash160
 
 ### Instructions
 
@@ -13,8 +13,8 @@ hash160 = sha256(ripemd160(input))
 ### Usage
 
 ```js
-let hash = hash160("Ducks");
-console.log(hash); // expected result : <Buffer de 5b 73 aa 85 84 02 d8 8c 36 d4 ff 85 29 65 d3 76 ac 6d 19>
+let hash = hash160('Ducks')
+console.log(hash) // expected result : <Buffer de 5b 73 aa 85 84 02 d8 8c 36 d4 ff 85 29 65 d3 76 ac 6d 19>
 ```
 
 ### Notions

--- a/subjects/blockchain/increment/README.md
+++ b/subjects/blockchain/increment/README.md
@@ -1,4 +1,4 @@
-# Increment
+## Increment
 
 Cryptographic algorithms use a `binary` representation of variables internally (`Buffer` in nodejs). `Hexadecimal` representation is used to facilitate human reading. To get more familiar with the hexadecimal form, we will do a simple operation.
 
@@ -9,10 +9,10 @@ Create a function `increment` that takes as argument a number written in hexadec
 ### Usage
 
 ```js
-increment("03"); // expected : <Buffer 04>
-increment("a0"); // expected : <Buffer a1>
-increment("ff"); // expected : <Buffer 01 00>
-increment("d537"); // expected : <Buffer d5 38>
+increment('03') // expected : <Buffer 04>
+increment('a0') // expected : <Buffer a1>
+increment('ff') // expected : <Buffer 01 00>
+increment('d537') // expected : <Buffer d5 38>
 ```
 
 ### Notions

--- a/subjects/blockchain/lineup/README.md
+++ b/subjects/blockchain/lineup/README.md
@@ -1,4 +1,4 @@
-# Lineup
+## Lineup
 
 For this to be a good festival, you need to register artists. Hip hip hip, arrays!
 

--- a/subjects/blockchain/local-node-info/README.md
+++ b/subjects/blockchain/local-node-info/README.md
@@ -1,4 +1,4 @@
-# Local Node Info
+## Local Node Info
 
 To start, we will create a simple page that displays basic information from our local node.
 

--- a/subjects/blockchain/local-node/README.md
+++ b/subjects/blockchain/local-node/README.md
@@ -1,4 +1,4 @@
-# Local Node
+## Local Node
 
 An Ethereum node provides different functionalities :
 
@@ -27,7 +27,7 @@ npm i ganache-cli
 npx ganache-cli
 ```
 
-*You can also use ganache ("non cli") that provides a nice graphical interface. For compatibility, change the listening port to 8545 in the settings*
+_You can also use ganache ("non cli") that provides a nice graphical interface. For compatibility, change the listening port to 8545 in the settings_
 
 Noticeably, local javascript nodes are not connected to any network and provide already 10 account populated with test ether.
 

--- a/subjects/blockchain/minimal-token/README.md
+++ b/subjects/blockchain/minimal-token/README.md
@@ -1,4 +1,4 @@
-# Minimal Token
+## Minimal Token
 
 It is now time to create our first token. We will start with a minmal implementation of a token.
 

--- a/subjects/blockchain/named-festival/README.md
+++ b/subjects/blockchain/named-festival/README.md
@@ -1,4 +1,4 @@
-# Named Festival
+## Named Festival
 
 In this exercise you will create your first smart contract! For a beginner friendly environment, I recommend [remix](https://remix.ethereum.org). It is an online IDE that provides many useful functionalities.
 

--- a/subjects/blockchain/nft-marketplace/README.md
+++ b/subjects/blockchain/nft-marketplace/README.md
@@ -1,4 +1,4 @@
-# NFT Marketplace
+## NFT Marketplace
 
 In this project, we will create a thematic NFT platform that references a genre of NFTs, displays them and allows NFTs trades. By genre of NFT, it can be a visual or thematic category, for instance all NFTs about mediaeval characters, a subcategory of NFTs, for example Profile Pictures (PFP), or more interestingly NFTs used for a particular usage, for instance software licences.
 

--- a/subjects/blockchain/node-dashboard/README.md
+++ b/subjects/blockchain/node-dashboard/README.md
@@ -2,7 +2,7 @@
 
 Blockchain nodes participate in a common peer-to-peer network retrieving information, executing and validating transactions and blocks. However, software clients differ in their functionalities and resource consumption. The purpose of this project is to create a tool, `benchy` that can launch, monitor and benchmark Ethereum networks.
 
-## launch-network
+### launch-network
 
 At first, we will focus on deploying a private Ethereum network while monitoring the nodes. The nodes can be launched directly or within containers.
 
@@ -12,7 +12,7 @@ At first, we will focus on deploying a private Ethereum network while monitoring
 
 The network should be launched with the command `benchy launch-network`. The nodes should be launched in the background and the command should return immediately.
 
-## Infos
+### Infos
 
 Using the `infos` command, Benchy should display information on each node, in the terminal or in a webpage. The information must include:
 
@@ -22,7 +22,7 @@ Using the `infos` command, Benchy should display information on each node, in th
 - Their current CPU and memory consumption (Hint: the outputs of commands such as `docker stats` or `ps` can be used)
 - Their corresponding Ethereum address and its balance.
 
-## Scenario
+### Scenario
 
 To analyze our network, we need to simulate some transactions. Benchy should propose the following scenarios available with the command `benchy scenario X`. Each scenario must provide feedback on its execution, including updated balances after transfers. 0. Initialise the network by letting it run for a few minutes. Validating nodes must have Eth available as reward or part of the initial configuration.
 
@@ -30,11 +30,11 @@ To analyze our network, we need to simulate some transactions. Benchy should pro
 2. Cassandra deploys an ERC20 smart contract with 3000 tokens BY, and gives 1000 to Driss and 1000 to Elena.
 3. Cassandra tries to send 1 ETH to Driss and immediately tries to cancel it by sending a transaction with a higher fee to send it to Elena.
 
-## temporary-failure
+### temporary-failure
 
 To study our network further, benchy can disrupt the current network by randomly stopping one node of the network. The command “temporary-failure X” stops the node X for 40 seconds and puts it back online.
 
-## Optional
+### Optional
 
 - _an option `-u [time] runs any command continuously each ‘time’ in seconds, 60 by default._
 - _Add the possibility to connect one node to a testnet network _

--- a/subjects/blockchain/node-dashboard/README.md
+++ b/subjects/blockchain/node-dashboard/README.md
@@ -1,14 +1,14 @@
-# A network dashboard and benchmarking tool
+## A network dashboard and benchmarking tool
 
-Blockchain nodes participate in a common peer-to-peer network retrieving information, executing and validating transactions and blocks. However, software clients differ in their functionalities and resource consumption. The purpose of this project is to create a tool, `benchy` that can launch, monitor and benchmark Ethereum networks. 
+Blockchain nodes participate in a common peer-to-peer network retrieving information, executing and validating transactions and blocks. However, software clients differ in their functionalities and resource consumption. The purpose of this project is to create a tool, `benchy` that can launch, monitor and benchmark Ethereum networks.
 
 ## launch-network
 
 At first, we will focus on deploying a private Ethereum network while monitoring the nodes. The nodes can be launched directly or within containers.
 
-* The network should consist of five nodes named Alice, Bob, Cassandra, Driss, and Elena. The first three are validating nodes. Each node has a corresponding Ethereum address.
-* Two different clients must be used, for instance, Geth and Nethermind
-* The consensus mechanism must be clique. 
+- The network should consist of five nodes named Alice, Bob, Cassandra, Driss, and Elena. The first three are validating nodes. Each node has a corresponding Ethereum address.
+- Two different clients must be used, for instance, Geth and Nethermind
+- The consensus mechanism must be clique.
 
 The network should be launched with the command `benchy launch-network`. The nodes should be launched in the background and the command should return immediately.
 
@@ -16,28 +16,27 @@ The network should be launched with the command `benchy launch-network`. The nod
 
 Using the `infos` command, Benchy should display information on each node, in the terminal or in a webpage. The information must include:
 
-* Their latest block
-* Their list of connected peers
-* The number of transactions in their mempool
-* Their current CPU and memory consumption (Hint: the outputs of commands such as `docker stats` or `ps` can be used)
-* Their corresponding Ethereum address and its balance.
-
+- Their latest block
+- Their list of connected peers
+- The number of transactions in their mempool
+- Their current CPU and memory consumption (Hint: the outputs of commands such as `docker stats` or `ps` can be used)
+- Their corresponding Ethereum address and its balance.
 
 ## Scenario
 
-To analyze our network, we need to simulate some transactions. Benchy should propose the following scenarios available with the command `benchy scenario X`. Each scenario must provide feedback on its execution, including updated balances after transfers.
-0.   Initialise the network by letting it run for a few minutes. Validating nodes must have Eth available as reward or part of the initial configuration. 
+To analyze our network, we need to simulate some transactions. Benchy should propose the following scenarios available with the command `benchy scenario X`. Each scenario must provide feedback on its execution, including updated balances after transfers. 0. Initialise the network by letting it run for a few minutes. Validating nodes must have Eth available as reward or part of the initial configuration.
+
 1. Alice sends every 10 seconds 0.1 ETH to Bob
 2. Cassandra deploys an ERC20 smart contract with 3000 tokens BY, and gives 1000 to Driss and 1000 to Elena.
 3. Cassandra tries to send 1 ETH to Driss and immediately tries to cancel it by sending a transaction with a higher fee to send it to Elena.
 
 ## temporary-failure
 
-To study our network further, benchy can disrupt the current network by randomly stopping one node of the network. The command “temporary-failure X” stops the node X for 40 seconds and puts it back online. 
+To study our network further, benchy can disrupt the current network by randomly stopping one node of the network. The command “temporary-failure X” stops the node X for 40 seconds and puts it back online.
 
 ## Optional
 
-* _an option `-u [time] runs any command continuously each ‘time’ in seconds, 60 by default._
-* _Add the possibility to connect one node to a testnet network _
-    * _Infos displays information only about this node_
-    * _`Scenario` runs the same scenarios on different addresses_
+- _an option `-u [time] runs any command continuously each ‘time’ in seconds, 60 by default._
+- _Add the possibility to connect one node to a testnet network _
+  - _Infos displays information only about this node_
+  - _`Scenario` runs the same scenarios on different addresses_

--- a/subjects/blockchain/node-dashboard/README.md
+++ b/subjects/blockchain/node-dashboard/README.md
@@ -24,11 +24,12 @@ Using the `infos` command, Benchy should display information on each node, in th
 
 ### Scenario
 
-To analyze our network, we need to simulate some transactions. Benchy should propose the following scenarios available with the command `benchy scenario X`. Each scenario must provide feedback on its execution, including updated balances after transfers. 0. Initialise the network by letting it run for a few minutes. Validating nodes must have Eth available as reward or part of the initial configuration.
+To analyze our network, we need to simulate some transactions. Benchy should propose the following scenarios available with the command `benchy scenario X`. Each scenario must provide feedback on its execution, including updated balances after transfers.
 
-1. Alice sends every 10 seconds 0.1 ETH to Bob
-2. Cassandra deploys an ERC20 smart contract with 3000 tokens BY, and gives 1000 to Driss and 1000 to Elena.
-3. Cassandra tries to send 1 ETH to Driss and immediately tries to cancel it by sending a transaction with a higher fee to send it to Elena.
+- Initialize the network by letting it run for a few minutes. Validating nodes must have Eth available as reward or part of the initial configuration.
+- Alice sends every 10 seconds 0.1 ETH to Bob
+- Cassandra deploys an ERC20 smart contract with 3000 tokens BY, and gives 1000 to Driss and 1000 to Elena.
+- Cassandra tries to send 1 ETH to Driss and immediately tries to cancel it by sending a transaction with a higher fee to send it to Elena.
 
 ### temporary-failure
 

--- a/subjects/blockchain/node-dashboard/audit/README.md
+++ b/subjects/blockchain/node-dashboard/audit/README.md
@@ -26,7 +26,7 @@
 
 ###### Does the command provide feedback?
 
-###### Does the `infos` command show the updated ETH balance? 
+###### Does the `infos` command show the updated ETH balance?
 
 ###### Does the `infos` command displays transactions in the mempool?
 
@@ -50,7 +50,7 @@
 
 ###### Does it appear to be up to date a couple of minutes later?
 
-#### Bonus 
+#### Bonus
 
 ###### +Does the `-u` option allow you to launch each command with a regular update?
 

--- a/subjects/blockchain/non-fungible-cats/README.md
+++ b/subjects/blockchain/non-fungible-cats/README.md
@@ -36,7 +36,7 @@ In addition, each token is linked to an Uniform Resource Identifier (URI) where 
 
 ---
 
-## Exercise 1: Napping Cats
+### Exercise 1: Napping Cats
 
 In this exercise we will create a basic NFT smart contract, and use it to instantiate an NFT collection with some custom functions
 
@@ -76,7 +76,7 @@ _Optionally, the price for new tokens is an auction. It starts at 100x of the in
 
 ---
 
-## Exercise 2: Showcase
+### Exercise 2: Showcase
 
 We will now be able to display our NFT collection on a website and allow user to use the interface to buy and sell tokens.
 
@@ -103,7 +103,7 @@ We will now be able to display our NFT collection on a website and allow user to
 
 ---
 
-## Exercise 3: Automated Reveal (Optional)
+### Exercise 3: Automated Reveal (Optional)
 
 In some auctions, NFT images are only revealed once purchased.
 

--- a/subjects/blockchain/non-fungible-cats/README.md
+++ b/subjects/blockchain/non-fungible-cats/README.md
@@ -1,4 +1,4 @@
-# Non Fungible Cats
+## Non Fungible Cats
 
 Today's quest objective is to master Non Fungible Tokens, NFTs.
 
@@ -36,7 +36,7 @@ In addition, each token is linked to an Uniform Resource Identifier (URI) where 
 
 ---
 
-# Exercise 1: Napping Cats
+## Exercise 1: Napping Cats
 
 In this exercise we will create a basic NFT smart contract, and use it to instantiate an NFT collection with some custom functions
 
@@ -76,7 +76,7 @@ _Optionally, the price for new tokens is an auction. It starts at 100x of the in
 
 ---
 
-# Exercise 2: Showcase
+## Exercise 2: Showcase
 
 We will now be able to display our NFT collection on a website and allow user to use the interface to buy and sell tokens.
 
@@ -103,7 +103,7 @@ We will now be able to display our NFT collection on a website and allow user to
 
 ---
 
-# Exercise 3: Automated Reveal (Optional)
+## Exercise 3: Automated Reveal (Optional)
 
 In some auctions, NFT images are only revealed once purchased.
 

--- a/subjects/blockchain/organized-festival/README.md
+++ b/subjects/blockchain/organized-festival/README.md
@@ -1,4 +1,4 @@
-# Organised Festival
+## Organised Festival
 
 In order for your festival to be properly managed, you need to define an organizer. The organizer will be the only user to have the right to modify certain properties. By default, you will define the organizer as the contract's deployer.
 

--- a/subjects/blockchain/payment-channel/README.md
+++ b/subjects/blockchain/payment-channel/README.md
@@ -1,6 +1,6 @@
-# Payment Channel
+## Payment Channel
 
-To overcome the scalability problem, two types of solutions have been devised. On the one hand the state and payment channels (_payment channels _and state channels_) and on the other hand the secondary chains (_sidechains)_ whose units of value are guaranteed by the main network.
+To overcome the scalability problem, two types of solutions have been devised. On the one hand the state and payment channels (_payment channels \_and state channels_) and on the other hand the secondary chains (_sidechains)_ whose units of value are guaranteed by the main network.
 
 Bitcoin offers a network of payment channels, the _lightning network_. On Ethereum there is Raiden, a network of payment channels, µRaiden a micropayments solution, and Counterfactual, a network of state channels. A state channel allows any state to be exchanged, while a payment channel allows only tokens to be exchanged.
 
@@ -32,7 +32,6 @@ As a first stage, we expect the project to work only for one channel between two
     +------------+           +------------+
     | Thunderd A |--connect--| Thunderd B |
     +------------+           +------------+
-
 
 ### Smart contract
 

--- a/subjects/blockchain/random-wallet/README.md
+++ b/subjects/blockchain/random-wallet/README.md
@@ -1,4 +1,4 @@
-# Random Wallet
+## Random Wallet
 
 You will have to create a simple web-based wallet.
 

--- a/subjects/blockchain/read-secret/README.md
+++ b/subjects/blockchain/read-secret/README.md
@@ -1,4 +1,4 @@
-# Read a Secret (Optional)
+## Read a Secret (Optional)
 
 ### Instructions
 
@@ -9,10 +9,11 @@ The smart contract is available at the address `0x467782A5ab90af6baA6f8af0b4E69A
 You might use the following interface :
 
 ```js
-const abi = ["function getSecret() view returns (string)"];
+const abi = ['function getSecret() view returns (string)']
 ```
 
 ⚠️ As the test does not reach the internet:
+
 - Store in a hardcoded manner the result in an element with `storedSecret` as id.
 - Detect when internet is not available and skip the connection to the provider.
 

--- a/subjects/blockchain/register-with-events/README.md
+++ b/subjects/blockchain/register-with-events/README.md
@@ -1,4 +1,4 @@
-# Register With Events
+## Register With Events
 
 In order to facilitate the use of your Smart Contract, you will add events.
 

--- a/subjects/blockchain/register/README.md
+++ b/subjects/blockchain/register/README.md
@@ -1,4 +1,4 @@
-# Register
+## Register
 
 To conveniently check for a given string or document, you will create a register smart contract.
 

--- a/subjects/blockchain/retrieve-block-date/README.md
+++ b/subjects/blockchain/retrieve-block-date/README.md
@@ -1,4 +1,4 @@
-# Retrieve Block Date
+## Retrieve Block Date
 
 ### Instructions
 
@@ -7,7 +7,7 @@ Using Node.js, create and exports a function `retrieveBlockDate()` that takes as
 ### Usage
 
 ```js
-retrieveBlockDate(1881467); // Expected : 2020-11-05T20:18:48.000Z
+retrieveBlockDate(1881467) // Expected : 2020-11-05T20:18:48.000Z
 ```
 
 ### Notions

--- a/subjects/blockchain/retrieve-transaction-in-out/README.md
+++ b/subjects/blockchain/retrieve-transaction-in-out/README.md
@@ -1,4 +1,4 @@
-# Retrieve Transaction In and Out
+## Retrieve Transaction In and Out
 
 A Bitcoin transaction consists of one or several inputs and one or several outputs. The sum of the inputs is slightly superior to the sum of the output to take into account the fee. One transaction per block, called "coinbase", pays miners and does not have a valid input. For some transactions, outputs might be null too.
 
@@ -29,8 +29,8 @@ rpcpassword=multipass
 ### Usage
 
 ```js
-txHash = "d030023d96b9170af9ec2fe5d9b62a5eacbcbf144c68f3f45d68bca72d1d3649";
-retrieveTxData(txHash);
+txHash = 'd030023d96b9170af9ec2fe5d9b62a5eacbcbf144c68f3f45d68bca72d1d3649'
+retrieveTxData(txHash)
 /* Expected : 
     { 
       in: [ 0.18075094 ], 

--- a/subjects/blockchain/retrieve-transaction-value/README.md
+++ b/subjects/blockchain/retrieve-transaction-value/README.md
@@ -1,4 +1,4 @@
-# Retrieve transaction value
+## Retrieve transaction value
 
 ### Instructions
 
@@ -16,10 +16,10 @@ rpcpassword=multipass
 ### Usage
 
 ```js
-const { retrieveTxValue } = require("./retrieveTransactionValue.js");
+const { retrieveTxValue } = require('./retrieveTransactionValue.js')
 retrieveTxValue(
-  "d030023d96b9170af9ec2fe5d9b62a5eacbcbf144c68f3f45d68bca72d1d3649"
-); // Expected : 50
+  'd030023d96b9170af9ec2fe5d9b62a5eacbcbf144c68f3f45d68bca72d1d3649',
+) // Expected : 50
 ```
 
 ### Hint

--- a/subjects/blockchain/semi-brute/README.md
+++ b/subjects/blockchain/semi-brute/README.md
@@ -1,4 +1,4 @@
-# Semi Brute
+## Semi Brute
 
 Hash functions are used to secure information. A piece of data, for instance a password, is hashed and only its hash is stored. While there is no way to compute on the original information, one can try every possible value. This is called a brute force attack.
 
@@ -13,8 +13,8 @@ Create a function `semiBrute()` that takes as argument a target, which is a two 
 ### Usage
 
 ```js
-solution = semiBrute("e2");
-console.log(solution);
+solution = semiBrute('e2')
+console.log(solution)
 // One valid result : 'abcdefghijklmnopqrs'
 // You might find other valid solutions as we only check the first two characters
 ```

--- a/subjects/blockchain/send-eth-transaction/README.md
+++ b/subjects/blockchain/send-eth-transaction/README.md
@@ -1,4 +1,4 @@
-# Send Eth Transaction
+## Send Eth Transaction
 
 You will create your first transaction on Ethereum using one of its testnets. We recommend Goerli as it is the most commonly used testnet, but you can use any other testnet.
 
@@ -16,7 +16,7 @@ You will create your first transaction on Ethereum using one of its testnets. We
 
 ```js
 exports.txid =
-  "0xf02c4a1487aa2e45fc2c77cb5a28713a1474d86d5f4292b264875ccc5da82b67";
+  '0xf02c4a1487aa2e45fc2c77cb5a28713a1474d86d5f4292b264875ccc5da82b67'
 ```
 
 ### Notions

--- a/subjects/blockchain/send-ether/README.md
+++ b/subjects/blockchain/send-ether/README.md
@@ -1,4 +1,4 @@
-# Send Ether
+## Send Ether
 
 In this exercise, you will send ETH using a script.
 
@@ -8,7 +8,7 @@ Write a node script that provides a function `sendEther(amount, address)` which 
 
 ```js
 function sendEther(amount, address) {
-    //...
+  //...
 }
 module.exports = sendEther
 ```

--- a/subjects/blockchain/send-hash/README.md
+++ b/subjects/blockchain/send-hash/README.md
@@ -1,4 +1,4 @@
-# Send Hash
+## Send Hash
 
 In this exercise, you will register the hash of a document on the blockchain.
 
@@ -14,7 +14,7 @@ Write a node script that provides a function `sendHash()` that:
 function sendHash(text) {
   //...
 }
-module.exports = sendHash;
+module.exports = sendHash
 ```
 
 ### Notions

--- a/subjects/blockchain/send-transaction-to-peer/README.md
+++ b/subjects/blockchain/send-transaction-to-peer/README.md
@@ -1,4 +1,4 @@
-# Send Transaction to Peer
+## Send Transaction to Peer
 
 You will send your first peer-to-peer transaction between two students.
 

--- a/subjects/blockchain/sign-service/README.md
+++ b/subjects/blockchain/sign-service/README.md
@@ -1,4 +1,4 @@
-# Sign Service
+## Sign Service
 
 The goal of this raid is to create a web service that allows users to upload, sign and store the hash of documents on the blockchain and to
 

--- a/subjects/blockchain/signer/README.md
+++ b/subjects/blockchain/signer/README.md
@@ -1,4 +1,4 @@
-# Signer
+## Signer
 
 Elliptic curve cryptography is used in most blockchain projects to sign transactions. Using Node.js base library we will practise simple signatures.
 
@@ -13,10 +13,10 @@ Elliptic curve cryptography is used in most blockchain projects to sign transact
 ### Usage
 
 ```js
-const message = "This is a message to sign";
-const pubKey = init();
-const signature = signer(message);
-console.log(verifier(message, pubKey, signature));
+const message = 'This is a message to sign'
+const pubKey = init()
+const signature = signer(message)
+console.log(verifier(message, pubKey, signature))
 // expected result :
 // true
 ```

--- a/subjects/blockchain/time-and-place/README.md
+++ b/subjects/blockchain/time-and-place/README.md
@@ -1,4 +1,4 @@
-# Time and Place
+## Time and Place
 
 To be considered a festival, you need to initially specify a time and a place. Everything else can be organized later.
 

--- a/subjects/blockchain/time-is-money/README.md
+++ b/subjects/blockchain/time-is-money/README.md
@@ -1,4 +1,4 @@
-# Time is Money
+## Time is Money
 
 We organize a bit of yield management. Tickets are now 0.01 ether if they are bought up to 10 days before the start of the festival and 0.1 afterward.
 

--- a/subjects/blockchain/token-sale/README.md
+++ b/subjects/blockchain/token-sale/README.md
@@ -1,4 +1,4 @@
-# Token Sale
+## Token Sale
 
 One way to distribute our token is to sell it. We will set a fixed price for each token. The tokens will have to be send to the Smart Contract by their owner initally.
 

--- a/subjects/blockchain/tracking-network/README.md
+++ b/subjects/blockchain/tracking-network/README.md
@@ -1,4 +1,4 @@
-# Tracking Network
+## Tracking Network
 
 We will create a network to track postal parcels using Hyperledger Fabric. Hyperledger Fabric is a modular blockchain framework. It revolves around a few key concepts. First, the notion of channel, which represents a network with a set of transactions and participants dedicated to the same business objective. Within a channel a transaction is validated by a set of designated peers. On this channel, Smart Contracts can be deployed as "chaincode" to define business logic that will control validation within this network.
 

--- a/subjects/blockchain/transfers-history/README.md
+++ b/subjects/blockchain/transfers-history/README.md
@@ -1,4 +1,4 @@
-# Transfers History
+## Transfers History
 
 ### Instructions
 
@@ -18,12 +18,12 @@ exports.transfersHistory = transfersHistory;
 #### Usage
 
 ```js
-const { transfersHistory } = require("./transfersHistory.js");
+const { transfersHistory } = require('./transfersHistory.js')
 
 transfersHistory(
-  "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc",
-  "0x70997970c51812dc3a010c7d01b50e0d17dc79c8"
-);
+  '0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc',
+  '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+)
 /* expected:
 [50, -25, 200, 30, -230]
 */

--- a/subjects/blockchain/usable-token/README.md
+++ b/subjects/blockchain/usable-token/README.md
@@ -1,4 +1,4 @@
-# Usable Token
+## Usable Token
 
 ### Instructions
 


### PR DESCRIPTION
I run the following script to reformat all the subjects inside `/public/subject/blockchain/`.
The objective is to have all the `README.md` `prettier` compliant and no `H1` block ("demoted" to `H2`)

```bash
#!/usr/bin/env bash 

IFS='
'

if [[ $# -lt 1 ]]; then
    echo "Run $0 with one or more aguments"
    exit 1
fi

format () {
    # assume prettier is installed 
    npx prettier -w "$1"
    # From H1 to H2 (only .md files)
    if [[ "$1" =~ .*\.md$ ]]; then
        sed -i 's:^# :## :' "$1"
    fi
}

for file in $@; do 
    if [[ !(-f $file) ]]; then 
       continue 
     fi
     format "$file"
done
```