### PR TITLE
DEV-4530-piscine-scripting-quest-4-division

### DIFF
--- a/sh/tests/Dockerfile
+++ b/sh/tests/Dockerfile
@@ -2,6 +2,7 @@ FROM docker.01-edu.org/debian:10.9-slim
 
 RUN apt-get update
 RUN apt-get -y install jq curl tree apt-utils
+RUN apt-get -y install bc
 
 WORKDIR /app/assets/superhero
 RUN curl --remote-name --location https://demo.01-edu.org/assets/superhero/all.json

--- a/sh/tests/division_test.sh
+++ b/sh/tests/division_test.sh
@@ -15,15 +15,8 @@ challenge() {
         return
     fi
 
-    # Test with one or two arguments
-    if [ $# -eq 1 ]
-    then
-    submitted=$(bash "$script_dirS"/student/division.sh $1)
-    expected=$(bash "$script_dirS"/solutions/division.sh $1)
-    else
-    submitted=$(bash "$script_dirS"/student/division.sh $1 $2)
-    expected=$(bash "$script_dirS"/solutions/division.sh $1 $2)
-    fi
+    submitted=$(bash "$script_dirS"/student/division.sh $@)
+    expected=$(bash "$script_dirS"/solutions/division.sh $@)
     diff <(echo "$submitted") <(echo "$expected")
 }
 


### PR DESCRIPTION
Added `bc` in Dockerfile since the dependency is required for `division` exercise.
It needs to stay on its own line since it needs `curl` to be installed.