### PR TITLE
DEV-4730-DEV-4529-fix-permission-denied-devops-tests

### DIFF
--- a/sh/tests/entrypoint.sh
+++ b/sh/tests/entrypoint.sh
@@ -6,6 +6,8 @@ cp -r /app .
 cp -a student app
 cd app
 
+chmod +x "./student/${EXERCISE}.sh"
+
 if ! test -f "${EXERCISE}_test.sh"; then
 	echo "No test file found for the exercise : $EXERCISE"
 	exit 1


### PR DESCRIPTION
give execution permission to student files to prevent permission denied on execution

This will prevent the error from appearing again in any exercise of bash part in devops branch