### PR TITLE
DEV-4753-dev-ops-scripting-piscine-exercises-failing-when-expected-file-doesnt-match-exercise-name

### DIFF
--- a/sh/tests/entrypoint.sh
+++ b/sh/tests/entrypoint.sh
@@ -6,7 +6,9 @@ cp -r /app .
 cp -a student app
 cd app
 
-chmod +x "./student/${EXERCISE}.sh"
+if test -f "./student/${EXERCISE}.sh"; then
+	chmod +x "./student/${EXERCISE}.sh"
+fi
 
 if ! test -f "${EXERCISE}_test.sh"; then
 	echo "No test file found for the exercise : $EXERCISE"


### PR DESCRIPTION
tests were failing when the exercise name didn't match the expected file
