### PR TITLE
Improve `tell-me-who` test

### DIFF
--- a/js/tests/tell-me-who_test.mjs
+++ b/js/tests/tell-me-who_test.mjs
@@ -44,6 +44,7 @@ tests.push(async ({ eq, ctx, randStr, upperFirst }) => {
 
   const { stdout } = await ctx.run(dirName)
   return eq(
+    stdout.split('\n'),
     [
       `1. Ballard Ubaid`,
       `2. Chan Victoria`,
@@ -51,7 +52,6 @@ tests.push(async ({ eq, ctx, randStr, upperFirst }) => {
       `4. Hamilton ${random}`,
       `5. Mullen Dominika`,
     ],
-    stdout.split('\n'),
   )
 })
 


### PR DESCRIPTION
- make the error message "actual" and "expected" coherent with the expected output and current solution output