### PR TITLE
`CON-1749` fix broken URL link in classification readme

### DIFF
--- a/subjects/ai/classification/README.md
+++ b/subjects/ai/classification/README.md
@@ -293,7 +293,7 @@ Preliminary:
 
 - https://scikit-learn.org/stable/modules/generated/sklearn.metrics.confusion_matrix.html
 
-- https://archive.ics.uci.edu/ml/machine-learning-databases/breast-cancer-wisconsin/
+- [Database](data/breast-cancer-wisconsin.data) and [database information](data/breast-cancer-wisconsin.names)
 
 ---
 ---


### PR DESCRIPTION
- redirect directly to local resources in data directory
