### PR TITLE
docs(SortArgs) - Fix bug in ExerciseRunner

### DIFF
--- a/subjects/java/piscine/SortArgs/README.md
+++ b/subjects/java/piscine/SortArgs/README.md
@@ -28,8 +28,13 @@ public class ExerciseRunner {
     public static void main(String[] args) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         PrintStream printStream = new PrintStream(outputStream);
+
+        var defaultOut = System.out;
+
         System.setOut(printStream);
-        SortArgs.sort(new String[]{"4","2","1","3"});
+        SortArgs.sort(new String[]{"4", "2", "1", "3"});
+        System.setOut(defaultOut);
+
         String output = outputStream.toString();
         System.out.println(output.equals("1 2 3 4\n"));
     }


### PR DESCRIPTION
Restores the default `System.out` to fix result printing

`System.out` was changed to a custom `printStream`, so 

```Java
System.out.println(output.equals("1 2 3 4\n"));
```

printed `true` or `false` to this `printStream` and not the default `System.out`. This caused console output to be empty.