### PR TITLE
CON-1980-Fix-issue-2139-CatInFile-exercise-runner-fails

### DIFF
--- a/subjects/java/piscine/CatInFile/README.md
+++ b/subjects/java/piscine/CatInFile/README.md
@@ -28,6 +28,8 @@ Here is a possible ExerciseRunner.java to test your function :
 
 ```java
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 public class ExerciseRunner {
     public static void main(String[] args) throws IOException {


### PR DESCRIPTION
The missing imports were added, the runner works fine now.