### PR TITLE
DEV-5379-javascript-discovery-conditions-exercice-buged

### DIFF
--- a/js/tests/test.mjs
+++ b/js/tests/test.mjs
@@ -130,10 +130,10 @@ ${provided ? '// Provided setup' : ''}
 ${provided.trim()}
 
 // Your code
-${solution.code.trim()}
+${solution.code.trim()};
 
 // The tests
-${tests.trim()}`.trim()
+${tests.trim()};`.trim()
 
     try {
       eval(fullCode)


### PR DESCRIPTION
This bug caused the exercises to be completed trivially by simply adding an if (false) statement. The fix is to add a semicolon after the if statement, which prevents the next line of code from executing.

Example:

javascript
let name = 'Arthur'
let excalibur = 'set in stone'

// Before:
equal(excalibur, 'pulled')

// After:
if (false);
equal(excalibur, 'pulled')