### PR TITLE
Flags are most likely in wrong order for the audit file

### DIFF
--- a/subjects/cybersecurity/active/audit/README.md
+++ b/subjects/cybersecurity/active/audit/README.md
@@ -43,11 +43,11 @@ The student must launch his program by passing the IP address of a website as th
 5900 VNC  
 25565 Minecraft
 
-##### Run `tinyscanner -p 127.0.0.1 -t 80`
+##### Run `tinyscanner -t 127.0.0.1 -p 80`
 
 ###### Does port 80 show as open?
 
-##### Run a local server using udp protocol with the port 8080 and run `tinyscanner -p 127.0.0.1 -u 80`
+##### Run a local server using udp protocol with the port 8080 and run `tinyscanner -u 127.0.0.1 -p 80`
 
 ###### Does port 80 show as open?
 


### PR DESCRIPTION
- It makes more sense for the flag -p (short for 'ports') to be before the port range
- It makes more sense for the flags -u or -t (short for 'UDP ports' and 'TCP ports') to be either freely placed where-ever or to be placed before the 'ip_address' argument, but not before the port range argument. This mistake happened only inside the audit questions file, it seems to be fine in the task description file.