### PR TITLE
DEV-5596 Improve Public build image on the branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,8 +16,7 @@ DEV-#### | SUP-#### | CON-####
 
 ### Build Images
 
-> Please check the relevant images
-
-- [ ] Build Sh Docker Image
-- [ ] Build JS Docker Image
-- [ ] Build DOM Docker Image 
+> Please assign the label `📦 build` If you want to re-build the following test images:
+>- `💻 Sh` 
+>- `🚀 JS`
+>- `🧩 DOM`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+> Before starting, please choose the relevant pull request **Labels**, **Reviewers**, and **Assignees**
+
+DEV-#### | SUP-#### | CON-####
+
+### Why?
+
+> Clearly state the reason for this change. What problem is it solving, or what feature is it adding?
+
+### Solution Overview
+
+> Provide an overview of the solution implemented in this pull request. This should be a high-level overview without getting into technical details. If applicable, include screenshots of UI or use GitHub compliant [`mermaid`](https://mermaid.live/) graphs to visually represent the solution.
+
+### Implementation Details
+
+> Explain the details of the implementation and the reasoning behind it. What alternative approaches were considered, and why was this approach chosen?
+
+### Build Images
+
+> Please check the relevant images
+
+- [ ] Build Sh Docker Image
+- [ ] Build JS Docker Image
+- [ ] Build DOM Docker Image 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ DEV-#### | SUP-#### | CON-####
 
 ### Solution Overview
 
-> Provide an overview of the solution implemented in this pull request. This should be a high-level overview without getting into technical details. If applicable, include screenshots of UI or use GitHub compliant [`mermaid`](https://mermaid.live/) graphs to visually represent the solution.
+> Provide an overview of the solution implemented in this pull request. This should be a high-level overview without getting into technical details. If applicable, include screenshots of UI or use GitHub-compliant [`mermaid`](https://mermaid.live/) graphs to represent the solution visually.
 
 ### Implementation Details
 

--- a/.github/workflows/ga-image-build-branch.yml
+++ b/.github/workflows/ga-image-build-branch.yml
@@ -28,19 +28,19 @@ jobs:
           password: ${{ secrets.SECRET_DOCKER_01EDU_ORG }}
 
       - name: 🏗️ Build the 💻 Sh Docker image
-        if: always()
+        if: github.event.pull_request.body.contains('[x] Build Sh Docker Image')
         run: |
           docker build sh/tests/ --file sh/tests/Dockerfile --tag ghcr.io/01-edu/test-sh:PR${{ github.event.pull_request.number }}
           docker push ghcr.io/01-edu/test-sh:PR${{ github.event.pull_request.number }}
 
       - name: 🏗️ Build the 🚀 JS Docker image
-        if: always()
+        if: github.event.pull_request.body.contains('[x] Build JS Docker Image')
         run: |
           docker build js/tests/ --file js/tests/Dockerfile --tag ghcr.io/01-edu/test-js:PR${{ github.event.pull_request.number }}
           docker push ghcr.io/01-edu/test-js:PR${{ github.event.pull_request.number }}
 
       - name: 🏗️ Build the 🧩 DOM Docker image
-        if: always()
+        if: github.event.pull_request.body.contains('[x] Build DOM Docker Image')
         run: |
           docker build . --file dom/Dockerfile --tag ghcr.io/01-edu/test-dom:PR${{ github.event.pull_request.number }}
           docker push ghcr.io/01-edu/test-dom:PR${{ github.event.pull_request.number }}

--- a/.github/workflows/ga-image-build-branch.yml
+++ b/.github/workflows/ga-image-build-branch.yml
@@ -9,6 +9,8 @@ jobs:
     name: 🏗️ Build Image - Branch
     runs-on: ubuntu-latest
 
+    if: contains(github.event.pull_request.labels.*.name, '📦 build')
+
     steps:
       - name: 🐧 Checkout
         uses: actions/checkout@v3
@@ -28,19 +30,19 @@ jobs:
           password: ${{ secrets.SECRET_DOCKER_01EDU_ORG }}
 
       - name: 🏗️ Build the 💻 Sh Docker image
-        if: github.event.pull_request.body.contains('[x] Build Sh Docker Image')
+        if: always()
         run: |
           docker build sh/tests/ --file sh/tests/Dockerfile --tag ghcr.io/01-edu/test-sh:PR${{ github.event.pull_request.number }}
           docker push ghcr.io/01-edu/test-sh:PR${{ github.event.pull_request.number }}
 
       - name: 🏗️ Build the 🚀 JS Docker image
-        if: github.event.pull_request.body.contains('[x] Build JS Docker Image')
+        if: always()
         run: |
           docker build js/tests/ --file js/tests/Dockerfile --tag ghcr.io/01-edu/test-js:PR${{ github.event.pull_request.number }}
           docker push ghcr.io/01-edu/test-js:PR${{ github.event.pull_request.number }}
 
       - name: 🏗️ Build the 🧩 DOM Docker image
-        if: github.event.pull_request.body.contains('[x] Build DOM Docker Image')
+        if: always()
         run: |
           docker build . --file dom/Dockerfile --tag ghcr.io/01-edu/test-dom:PR${{ github.event.pull_request.number }}
           docker push ghcr.io/01-edu/test-dom:PR${{ github.event.pull_request.number }}

--- a/.github/workflows/ga-image-build-branch.yml
+++ b/.github/workflows/ga-image-build-branch.yml
@@ -3,6 +3,7 @@ name: 🌳 On Branch - Build and Test Docker Image
 on:
   pull_request:
     branches: ["master"]
+    types: [ labeled, opened, reopened, synchronize ]
 
 jobs:
   build-image:


### PR DESCRIPTION
> Before starting, please choose the relevant pull request **Labels**, **Reviewers**, and **Assignees**

DEV-5596

### Why?

> Clearly state the reason for this change. What problem is it solving, or what feature is it adding?

Currently, the PRs that are opened by non-01 authors are not being able to be merged due to the lack of permission for external members to build images under our organization's repository. 

### Solution Overview

> Provide an overview of the solution implemented in this pull request. This should be a high-level overview without getting into technical details. If applicable, include screenshots of UI or use GitHub compliant [`mermaid`](https://mermaid.live/) graphs to visually represent the solution.

We are incorporating a standardized and appropriate pull request template, similar to the rest of our repositories and as previously implemented in the Public repository, and incorporating a relevant label for the images to be built on PR. Based on the PR's requirement, it seems to be the most suitable option.

### Implementation Details

> Explain the details of the implementation and the reasoning behind it. What alternative approaches were considered, and why was this approach chosen?

- Add PR template.
- Add a relevant label and checks.
- Modify the existing CI/CD pipeline to incorporate the changes.

### Build Images

> Please assign the label `📦 build` If you want to re-build the following test images:
>- `💻 Sh` 
>- `🚀 JS`
>- `🧩 DOM`