### PR TITLE
[EXTERNAL] add strings to forbidden

### DIFF
--- a/subjects/cybersecurity/hole-in-bin/README.md
+++ b/subjects/cybersecurity/hole-in-bin/README.md
@@ -43,3 +43,4 @@ Files that must be inside your repository:
 - All tools you use, and any scripts you write.
 
 > It's forbidden to use external scripts, in the audit you will be asked different questions about the concepts and the practices of this project, prepare yourself!
+> It's is forbidden to use `strings` command.


### PR DESCRIPTION
every exercise can currently be solved by using strings for example

` strings bin | grep "modified"` 

to give the message required to complete the exercise.

However, that technique will teach us nothing about binary inspection, reverse engineering or binary manipulation.

> Before starting, please choose the relevant pull request **Labels**, **Reviewers**, and **Assignees**

DEV-#### | SUP-#### | CON-####

### Why?

> It is important to learn concepts, not circumvent the exercise.

### Solution Overview

> Explicitly forbid strings command

### Implementation Details

> Added one line to README

### Build Images

> Please assign the label `📦 build` If you want to re-build the following test images:
>- `💻 Sh` 
>- `🚀 JS`
>- `🧩 DOM`
