### PR TITLE
Fix typo in shop README.md

### DIFF
--- a/subjects/shop/README.md
+++ b/subjects/shop/README.md
@@ -11,9 +11,9 @@ As mentioned, some of the process is already done. So first of all, let's see wh
 
 ### Instructions
 
-In this website the goal is for you to fix it so that it will be possible to create users. Additionally, those users will be able to create adds to sell products in the website.
+In this website the goal is for you to fix it so that it will be possible to create users. Additionally, those users will be able to create ads to sell products in the website.
 
-To create an add you will have to go to the `Sell` button and create the add. You will be able to give a title to your add, a price, a model and a description. You also must select a brand, a color and a condition for your product. Moreover, you will be able to choose images from your folder in app/assets/images.
+To create an ad you will have to go to the `Sell` button and create the ad. You will be able to give a title to your ad, a price, a model and a description. You also must select a brand, a color and a condition for your product. Moreover, you will be able to choose images from your folder in app/assets/images.
 
 First you will have to implement a controller called `registrations_controller` that can be found incomplete in app/controllers. You will need [Devise](https://github.com/heartcombo/devise) which is a flexible authentication solution for Rails based on Warden.
 
@@ -34,9 +34,9 @@ The second one is`account_update_params` where you will also need to allow the n
         - password_confirmation
         - current_password
 
-- You will also need to complete the `products_helper.rb` located in app/helpers. This helper will be responsible for showing who is selling the products and who is able to edit and delete the adds(in this case the creator of the add). So you will have to find a way to show the name of the seller in each product.
+- You will also need to complete the `products_helper.rb` located in app/helpers. This helper will be responsible for showing who is selling the products and who is able to edit and delete the ads (in this case the creator of the ad). So you will have to find a way to show the name of the seller in each product.
 
-- You have to find a way so that, only the user who creates an add, can edit or also permanently delete it.
+- You have to find a way so that, only the user who creates an ad, can edit or also permanently delete it.
 
 - All e-Commerce apps need some sort of Cart. So you will have to create a shopping cart for your application.
 
@@ -99,7 +99,7 @@ You should do this steps after unzipping:
 As bonus for this project there are a couple things you could do:
 
 - You can add a category to the product so that the user can chose between cars, clothes, computers and many more. Or you can add more fields to describe the products, for example add more brands.
-- You can create a button `add to cart` so that it is possible to add a product to the cart without opening the adds.
+- You can create a button `add to cart` so that it is possible to add a product to the cart without opening the ads.
 - You can find a way to remove items from the cart one by one.
 - You can implement your own display and design.
 - You can add a payment method.

--- a/subjects/shop/audit/README.md
+++ b/subjects/shop/audit/README.md
@@ -10,29 +10,29 @@
 
 ###### Is it impossible to edit and delete products that were not created by your user?
 
-##### Try to sell a product by creating an add with the user created.
+##### Try to sell a product by creating an ad with the user created.
 
-###### Is it possible to create adds and sell a product using your user?
+###### Is it possible to create ads and sell a product using your user?
 
-##### Navigate to the homepage and try to edit the add that you have created.
+##### Navigate to the homepage and try to edit the ad that you have created.
 
-###### Is it possible for you to edit your own add?
+###### Is it possible for you to edit your own ad?
 
-##### Try to create another new user, login and create at least two new adds.
+##### Try to create another new user, login and create at least two new ads.
 
-###### Can you confirm that the new user and the adds were created?
+###### Can you confirm that the new user and the ads were created?
 
-##### Login in with the first user and check if the adds created by the second user are there.
+##### Login in with the first user and check if the ads created by the second user are there.
 
-###### Can you confirm that the adds created by the second user are present?
+###### Can you confirm that the ads created by the second user are present?
 
-##### Navigate to the homepage with a user of your choice and try to delete an add that you have created.
+##### Navigate to the homepage with a user of your choice and try to delete an ad that you have created.
 
-###### Is it possible for you to delete your own add?
+###### Is it possible for you to delete your own ad?
 
 ##### Navigate to the homepage with any user and try to check who is selling each product.
 
-###### Is it possible for you to see who is selling the products without opening the add?
+###### Is it possible for you to see who is selling the products without opening the ad?
 
 ##### Navigate to the homepage and try to find the cart icon.
 
@@ -84,7 +84,7 @@
 
 ###### +Can you confirm that the student created or added something new like a new brand or the category field?
 
-###### +Can you add a product to the cart without opening the add?
+###### +Can you add a product to the cart without opening the ad?
 
 ###### +If you add four products to the cart from the same seller, can you remove just one from the cart and keep the other three?
 


### PR DESCRIPTION
### Why?

> This change fixes a typo in the README.md file located in the subjects/shop directory. Also the README.md file located in the audit folder within that path. The typo impacts the clarity of the instructions provided in the file.

### Solution Overview

> The solution involves correcting the typo in the README.md file to ensure that instructions are accurately conveyed to users of the project. This will improve the readability and usability of the documentation.

### Implementation Details

> The typo was identified in the Instructions section of the README.md file, where the word "adds" was incorrectly used instead of "ads". This change has been made to ensure consistency and clarity throughout the document.