### PR TITLE
CON-2716 Fix inconsistency between `ascii-art-color` subject and audit

### DIFF
--- a/subjects/ascii-art/color/README.md
+++ b/subjects/ascii-art/color/README.md
@@ -35,7 +35,7 @@ Additionally, the program must still be able to run with a single `[STRING]` arg
 
 ### Allowed packages
 
-- Only the [standard Go](https://golang.org/pkg/) packages are allowed
+- Only the [standard Go](https://pkg.go.dev/std) packages are allowed
 
 This project will help you learn about :
 

--- a/subjects/ascii-art/color/README.md
+++ b/subjects/ascii-art/color/README.md
@@ -22,7 +22,7 @@ EX: go run . --color=<color> <substring to be colored> "something"
 $ go run . --color=red kit "a king kitten have kit"
 ```
 
-For the example above, the substring kit in the word kitten and the word kit at the end should be colored.
+For the example above, the substring `kit` in the word `kitten` and the word `kit` at the end should be colored.
 
 If there are other `ascii-art` optional projects implemented, the program should accept other correctly formatted `[OPTION]` and/or `[BANNER]`.
 Additionally, the program must still be able to run with a single `[STRING]` argument.

--- a/subjects/ascii-art/color/README.md
+++ b/subjects/ascii-art/color/README.md
@@ -4,9 +4,9 @@
 
 You must follow the same [instructions](../README.md) as in the first subject but this time with colors.
 
-The output should manipulate colors using the **flag** `--color=<color> <letters to be colored>`, in which `--color` is the flag and `<color>` is the color desired by the user and `<letters to be colored>` is the letter or letters that you can chose to be colored. These colors can be achieved using different notations (color code systems, like `RGB`, `hsl`, `ANSI`...), it is up to you to choose which one you want to use.
+The output should manipulate colors using the **flag** `--color=<color> <letters to be colored>`, in which `--color` is the flag and `<color>` is the color desired by the user and `<letters to be colored>` is the letter or word that you can chose to be colored. These colors can be achieved using different notations (color code systems, like `RGB`, `hsl`, `ANSI`...), it is up to you to choose which one you want to use.
 
-- You should be able to choose between coloring a single letter or a set of letters.
+- You should be able to choose between coloring a single letter or a word.
 - If the letter is not specified, the whole `string` should be colored.
 - The flag must have exactly the same format as above, any other formats must return the following usage message:
 

--- a/subjects/ascii-art/color/README.md
+++ b/subjects/ascii-art/color/README.md
@@ -4,16 +4,16 @@
 
 You must follow the same [instructions](../README.md) as in the first subject but this time with colors.
 
-The output should manipulate colors using the **flag** `--color=<color> <letters to be colored>`, in which `--color` is the flag and `<color>` is the color desired by the user and `<letters to be colored>` is the letter or word that you can chose to be colored. These colors can be achieved using different notations (color code systems, like `RGB`, `hsl`, `ANSI`...), it is up to you to choose which one you want to use.
+The output should manipulate colors using the **flag** `--color=<color> <substring to be colored>`, in which `--color` is the flag and `<color>` is the color desired by the user and `<substring to be colored>` is the substring that you can chose to be colored. These colors can be achieved using different notations (color code systems, like `RGB`, `hsl`, `ANSI`...), it is up to you to choose which one you want to use.
 
-- You should be able to choose between coloring a single letter or a word.
-- If the letter is not specified, the whole `string` should be colored.
+- The substring to be colored can be a single letter or more
+- If the substring is not specified, the whole `string` should be colored.
 - The flag must have exactly the same format as above, any other formats must return the following usage message:
 
 ```console
 Usage: go run . [OPTION] [STRING]
 
-EX: go run . --color=<color> <letters to be colored> "something"
+EX: go run . --color=<color> <substring to be colored> "something"
 ```
 
 If there are other `ascii-art` optional projects implemented, the program should accept other correctly formatted `[OPTION]` and/or `[BANNER]`.

--- a/subjects/ascii-art/color/README.md
+++ b/subjects/ascii-art/color/README.md
@@ -15,6 +15,12 @@ Usage: go run . [OPTION] [STRING]
 
 EX: go run . --color=<color> <substring to be colored> "something"
 ```
+### Example
+```shell
+go run . --color=red "kit" "a king kitten have kit"
+```
+for the above example the substring kit in the word kitten and the word kit at the end should be colored.
+
 
 If there are other `ascii-art` optional projects implemented, the program should accept other correctly formatted `[OPTION]` and/or `[BANNER]`.
 Additionally, the program must still be able to run with a single `[STRING]` argument.

--- a/subjects/ascii-art/color/README.md
+++ b/subjects/ascii-art/color/README.md
@@ -15,12 +15,14 @@ Usage: go run . [OPTION] [STRING]
 
 EX: go run . --color=<color> <substring to be colored> "something"
 ```
-### Example
-```shell
-go run . --color=red "kit" "a king kitten have kit"
-```
-for the above example the substring kit in the word kitten and the word kit at the end should be colored.
 
+### Usage
+
+```shell
+$ go run . --color=red kit "a king kitten have kit"
+```
+
+For the example above, the substring kit in the word kitten and the word kit at the end should be colored.
 
 If there are other `ascii-art` optional projects implemented, the program should accept other correctly formatted `[OPTION]` and/or `[BANNER]`.
 Additionally, the program must still be able to run with a single `[STRING]` argument.

--- a/subjects/ascii-art/color/README.md
+++ b/subjects/ascii-art/color/README.md
@@ -35,7 +35,7 @@ Additionally, the program must still be able to run with a single `[STRING]` arg
 
 ### Allowed packages
 
-- Only the [standard Go](https://pkg.go.dev/std) packages are allowed
+- Only the [standard Go](https://golang.org/pkg) packages are allowed
 
 This project will help you learn about :
 

--- a/subjects/ascii-art/color/audit/README.md
+++ b/subjects/ascii-art/color/audit/README.md
@@ -24,7 +24,7 @@ EX: go run . --color=<color> <substring to be colored> "something"
 
 ###### Does it display the expected result?
 
-##### Try specifying a substring to be colored  (the second until the last letter).
+##### Try specifying a substring to be colored (the second until the last letter).
 
 ###### Does it display the expected result (the corresponding substring with that color)?
 
@@ -32,7 +32,7 @@ EX: go run . --color=<color> <substring to be colored> "something"
 
 ###### Does it display the expected result (the corresponding letter with that color)?
 
-##### Try specifying a substring to be colored  (just two letters).
+##### Try specifying a substring to be colored (just two letters).
 
 ###### Does it display the expected result (the corresponding substring with that color)?
 

--- a/subjects/ascii-art/color/audit/README.md
+++ b/subjects/ascii-art/color/audit/README.md
@@ -1,6 +1,6 @@
 #### Functional
 
-###### Has the requirement for the allowed packages been respected? (Reminder for this project: only [standard packages](https://golang.org/pkg/))
+###### Has the requirement for the allowed packages been respected? (Reminder for this project: only [standard packages](https://pkg.go.dev/std))
 
 ##### Try passing as arguments `--color red "banana" `.
 

--- a/subjects/ascii-art/color/audit/README.md
+++ b/subjects/ascii-art/color/audit/README.md
@@ -7,7 +7,7 @@
 ```
 Usage: go run . [OPTION] [STRING]
 
-EX: go run . --color=<color> <letters to be colored> "something"
+EX: go run . --color=<color> <substring to be colored> "something"
 ```
 
 ###### Does it display the same result as above?
@@ -24,17 +24,17 @@ EX: go run . --color=<color> <letters to be colored> "something"
 
 ###### Does it display the expected result?
 
-##### Try specifying a set of letters to be colored (the second until the last letter).
+##### Try specifying a substring to be colored  (the second until the last letter).
 
-###### Does it display the expected result (the corresponding set of letters with that color)?
+###### Does it display the expected result (the corresponding substring with that color)?
 
 ##### Try specifying letter to be colored (the second letter).
 
 ###### Does it display the expected result (the corresponding letter with that color)?
 
-##### Try specifying a set of letters to be colored (just two letters).
+##### Try specifying a substring to be colored  (just two letters).
 
-###### Does it display the expected result (the corresponding set of letters with that color)?
+###### Does it display the expected result (the corresponding substring with that color)?
 
 ##### Try passing as arguments `--color=orange GuYs "HeY GuYs"`, in order to color `GuYs`.
 
@@ -56,7 +56,7 @@ EX: go run . --color=<color> <letters to be colored> "something"
 
 ###### Does it display the expected result?
 
-##### Try passing as arguments a random string with lower case letters, upper case letters, spaces and numbers with a random color in the color flag ("--color="), specifying a set of letters to be colored.
+##### Try passing as arguments a random string with lower case letters, upper case letters, spaces and numbers with a random color in the color flag ("--color="), specifying a substring to be colored .
 
 ###### Does it display the expected result?
 

--- a/subjects/ascii-art/color/audit/README.md
+++ b/subjects/ascii-art/color/audit/README.md
@@ -1,6 +1,6 @@
 #### Functional
 
-###### Has the requirement for the allowed packages been respected? (Reminder for this project: only [standard packages](https://pkg.go.dev/std))
+###### Has the requirement for the allowed packages been respected? (Reminder for this project: only [standard packages](https://golang.org/pkg/) )
 
 ##### Try passing as arguments `--color red "banana" `.
 


### PR DESCRIPTION
[CON-2716](https://01talent.atlassian.net/browse/CON-2716)

[CON-2716]: https://01talent.atlassian.net/browse/CON-2716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ