### PR TITLE
CON-3045 Tests(DPxAI): Upload test for quest01 objects-around

### DIFF
--- a/js/tests/objects-around.json
+++ b/js/tests/objects-around.json
@@ -1,19 +1,19 @@
 [
   {
-    "description": "variable robot is declared and of type object",
-    "code": "equal(typeof robot, 'object')"
+    "description": "variable myRobot is declared and of type object",
+    "code": "let robot = {\n  name: 'Freddy',\n  age: 27,\n  hasEnergy: false,\n}\n\n// Your code\n\nequal(typeof myRobot, 'object')"
   },
   {
-    "description": "property name from robot is of type string",
-    "code": "equal(typeof robot.name, 'string')"
+    "description": "property name from myRobot is of type string",
+    "code": "let robot = {\n  name: 'Freddy',\n  age: 27,\n  hasEnergy: false,\n}\n\n// Your code\n\nequal(typeof myRobot.name, 'string')"
   },
   {
-    "description": "property age from robot is of type number",
-    "code": "equal(typeof robot.age, 'number')"
+    "description": "property age from myRobot is of type number",
+    "code": "let robot = {\n  name: 'Freddy',\n  age: 27,\n  hasEnergy: false,\n}\n\n// Your code\n\nequal(typeof myRobot.age, 'number')"
   },
   {
-    "description": "property hasEnergy from robot is of type boolean",
-    "code": "equal(typeof robot.hasEnergy, 'boolean')"
+    "description": "property hasEnergy from myRobot is of type boolean",
+    "code": "let robot = {\n  name: 'Freddy',\n  age: 27,\n  hasEnergy: false,\n}\n\n// Your code\n\nequal(typeof myRobot.hasEnergy, 'boolean')"
   },
   {
     "description": "all 3 variable should be defined and have the right values",

--- a/js/tests/objects-around.json
+++ b/js/tests/objects-around.json
@@ -1,0 +1,26 @@
+[
+  {
+    "description": "variable robot is declared and of type object",
+    "code": "equal(typeof robot, 'object')"
+  },
+  {
+    "description": "property name from robot is of type string",
+    "code": "equal(typeof robot.name, 'string')"
+  },
+  {
+    "description": "property age from robot is of type number",
+    "code": "equal(typeof robot.age, 'number')"
+  },
+  {
+    "description": "property hasEnergy from robot is of type boolean",
+    "code": "equal(typeof robot.hasEnergy, 'boolean')"
+  },
+  {
+    "description": "all 3 variable should be defined and have the right values",
+    "code": "let robot = {\n  name: 'Freddy',\n  age: 27,\n  hasEnergy: false,\n}\n\n// Your code\n\nequal({ name, age, hasEnergy }, robot)"
+  },
+  {
+    "description": "value should also work for Jean-Pierre",
+    "code": "let robot = {\n  name: 'Jean-Pierre',\n  age: 65,\n  hasEnergy: true,\n}\n\n// Your code\n\nequal({ name, age, hasEnergy }, robot)"
+  }
+]


### PR DESCRIPTION
`https://01talent.atlassian.net/browse/CON-3045`

>  -> the two last tests cannot work because the test declare the object called robot and the solution declare it also. So the subject should probably ask to search for name age and hasEnergy in another variable name than robot to avoid conflict.
Fixed