### PR TITLE
CON-3183 Fixing instructions in `AI.GO/only-if`

### DIFF
--- a/subjects/AI.GO/only-if/README.md
+++ b/subjects/AI.GO/only-if/README.md
@@ -113,13 +113,19 @@ Your Robot must always seek the truth.
 
 #### Task 2:
 
-Your `RoboGuard's traveling company` has a special promotion for robot members aged between 18 (included) and 25 (included). Write the if condition that will check if the robot user can benefit from the promotion:
+Your `RoboGuard's traveling company` has a special promotion for robot members aged between 18 (included) and 25 (included).
 
-- `user.age` must be more than `17`.
+**NB: The ticket variable has already been declared, so do not declare it again.**
+
+1- Assign the message "You cannot benefit from our special promotion" to the ticket variable.
+
+2- Use an if statement to check that all these conditions are true:
+
+- `user.age` must be greater than or equal to `18`.
 - `user.age` must be less than or equal to `25`.
 - `user.activeMembership` must be `true`.
 
-If `all` of these conditions are `true`, log the message '`You can benefit from our special promotion`'.
+3- If all conditions are true, update the ticket variable with the message: "You can benefit from our special promotion".
 
 > Hint : use AND Operator in your condition!
 

--- a/subjects/AI.GO/only-if/README.md
+++ b/subjects/AI.GO/only-if/README.md
@@ -109,15 +109,15 @@ if (temperature < 8) {
 Your Robot must always seek the truth.
 
 - Check if the value of the provided variable `truth` is truthy, log the string: `The truth was spoken.`
-- Otherwise, log the string: `Lies !!!!` because the value of the provided variable truth is falsy.
+- Otherwise, log the string: `Lies !!!!` because the value of the provided variable `truth` is falsy.
 
 #### Task 2:
 
 Your `RoboGuard's traveling company` has a special promotion for robot members aged between 18 (included) and 25 (included).
 
-**NB: The ticket variable has already been declared, so do not declare it again.**
+**NB: The variable ticket has already been declared, so do not declare it again.**
 
-1- Assign the message "You cannot benefit from our special promotion" to the ticket variable.
+1- Assign the message "You cannot benefit from our special promotion" to the variable `ticket`.
 
 2- Use an if statement to check that all these conditions are true:
 
@@ -125,20 +125,20 @@ Your `RoboGuard's traveling company` has a special promotion for robot members a
 - `user.age` must be less than or equal to `25`.
 - `user.activeMembership` must be `true`.
 
-3- If all conditions are true, update the ticket variable with the message: "You can benefit from our special promotion".
+3- If all conditions are true, update the variable `ticket` with the message: "You can benefit from our special promotion".
 
-> Hint : use AND Operator in your condition!
+> Hint : use an AND Operator in your condition!
 
 #### Task 3:
 
 Your RoboGuard is selling plane tickets, each costing `9.99$`. The RoboGuard must confirm that the customer robot has the means to buy this ticket.
 
-The customer robot may have enough cash `or` a voucher.
+The customer robot may have enough cash **or** be in possesion of a voucher.
 
 Check if the provided variable customer can afford the ticket:
 
 If the customer has enough `cash` (`customer.cash` property)
-`or` If the customer has a `voucher` (`customer.hasVoucher` property is true)
+**OR** If the customer has a `voucher` (`customer.hasVoucher` property is true)
 
 If so, `increment` the provided variable `ticketSold` value by `1`.
 


### PR DESCRIPTION
### Why?

The instructions were not clarifying enough what will be tested.This goes with tests following the old exercise : special promo.

### Solution Overview

Added clear instructions that are compatible with the tests.