### PR TITLE
fix(rust-roman_numbers): remove conflicting traits from expected data structure

### DIFF
--- a/subjects/roman_numbers/README.md
+++ b/subjects/roman_numbers/README.md
@@ -25,7 +25,7 @@ pub enum RomanDigit {
 	M,
 }
 
-#[derive(Debug, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RomanNumber(pub Vec<RomanDigit>);
 
 impl From<u32> for RomanDigit {


### PR DESCRIPTION
### Why?
> The expected functions and Usage of the `roman_numbers` task of the `traits` quest has a conflicting implementation of traits, aka duplicate usage of the `debug` trait, which leads to compilation error. This PR removes this conflict/duplication of traits.

### Solution Overview
> The solution only removes the duplicate trait from the readme, to remove the duplication and avoid the compilation error.
