### PR TITLE
[EXTERNAL] Add links to valuable resource: `forum`, `real-time-forum`, `social-network` 

### DIFF
--- a/subjects/forum/README.md
+++ b/subjects/forum/README.md
@@ -91,7 +91,7 @@ This project will help you learn about:
 - The basics of web :
   - HTML
   - HTTP
-  - Sessions and cookies
+  - [Sessions](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-management-waf-protections) and [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies)
 - Using and [setting up Docker](https://docs.docker.com/get-started/)
   - Containerizing an application
   - Compatibility/Dependency

--- a/subjects/forum/authentication/README.md
+++ b/subjects/forum/authentication/README.md
@@ -25,5 +25,5 @@ Some examples of authentication means are:
 
 This project will help you learn about:
 
-- Sessions and cookies
+- [Sessions](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-management-waf-protections) and [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies)
 - Protecting routes

--- a/subjects/forum/security/README.md
+++ b/subjects/forum/security/README.md
@@ -16,7 +16,7 @@ For this project you must take into account the security of your forum.
 
 - You should encrypt at least the clients passwords. As a Bonus you can also encrypt the database, for this you will have to create a password for your database.
 
-Sessions and cookies were implemented in the [previous project](../README.md) but not under-pressure (tested in an attack environment). So this time you must take this into account.
+[Sessions](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-management-waf-protections) and [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies) were implemented in the [previous project](../README.md) but not under-pressure (tested in an attack environment). So this time you must take this into account.
 
 - Clients session cookies should be unique. For instance, the session state is stored on the server and the session should present an unique identifier. This way the client has no direct access to it. Therefore, there is no way for attackers to read or tamper with session state.
 

--- a/subjects/real-time-forum/README.md
+++ b/subjects/real-time-forum/README.md
@@ -82,7 +82,7 @@ This project will help you learn about:
 - The basics of web :
   - HTML
   - HTTP
-  - Sessions and cookies
+  - [Sessions](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-management-waf-protections) and [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies)
   - CSS
   - Backend and Frontend
   - DOM

--- a/subjects/social-network/README.md
+++ b/subjects/social-network/README.md
@@ -51,7 +51,7 @@ This is typically divided into three major parts:
 
 The backend may consist, like said above, of an **app** containing all the backend logic. This logic will therefore have several middleware, for example:
 
-- Authentication, since HTTP is a stateless protocol, we can use several ways to overcome and authenticate a client/user. You must use [sessions](https://allaboutcookies.org/what-are-session-cookies) and cookies.
+- Authentication, since HTTP is a stateless protocol, we can use several ways to overcome and authenticate a client/user. You must use [sessions](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-management-waf-protections) and [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies).
 - Images handling, supporting various types of extensions. In this project you have to handle at least JPEG, PNG and GIF types. You will have to store the images, it can be done by storing the file/path in the database and saving the image in a specific file system.
 - Websocket, handling the connections in real time, between clients. This will help with the private chats.
 
@@ -135,7 +135,7 @@ In order for the users to use the social network they will have to make an accou
 
 Note that the **Avatar/Image**, **Nickname** and **About Me** should be present in the form but the user can skip the filling of those fields.
 
-When the user logins, he/she should stay logged in until he/she chooses a logout option that should be available at all times. For this you will have to implement [sessions](https://allaboutcookies.org/what-are-session-cookies) and [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies).
+When the user logins, he/she should stay logged in until he/she chooses a logout option that should be available at all times. For this you will have to implement [sessions](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-management-waf-protections) and [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies).
 
 You can implement your own package for sessions and cookies or you can take a look at some packages to help you.
 
@@ -229,7 +229,7 @@ Every other notification created by you that isn't on the list is welcomed too.
 ### Allowed Packages
 
 - The [standard Go](https://golang.org/pkg/) packages are allowed
-- [Gorilla](https://pkg.go.dev/github.com/gorilla/websocket) websocket
+- [Gorilla websocket](https://pkg.go.dev/github.com/gorilla/websocket)
 - [golang-migrate](https://github.com/golang-migrate/migrate/)
 - [sql-migration](https://pkg.go.dev/github.com/rubenv/sql-migrate)
 - [migration](https://pkg.go.dev/github.com/Boostport/migration)


### PR DESCRIPTION
In `social-network` I replaced the [allaboutcookies - sessions](https://allaboutcookies.org/what-are-session-cookies) link with [cheatsheetseries.owasp - sessions](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-management-waf-protections), as the former lacks depth and is ad-heavy. The new resource provides comprehensive guidance on web session management, including session ID handling, secure cookies, storage APIs, attack prevention, and monitoring.

I also added this link, along with [developer.mozilla - cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies) to the previous projects `forum` and `real-time-forum` where they are most needed.





