### PR TITLE
[EXTERNAL] `forum-security` Remove redundant question

### DIFF
--- a/subjects/forum/security/audit.md
+++ b/subjects/forum/security/audit.md
@@ -28,9 +28,7 @@
 
 #### General
 
-###### +Does the project implement their own certificates for the HTTPS protocol?
-
-###### +Does the project implement UUID(Universal Unique Identifier) for the user session?
+###### +Does the project implement its own certificates for the HTTPS protocol?
 
 ###### +Does the database present a password for protection?
 

--- a/subjects/forum/security/audit/README.md
+++ b/subjects/forum/security/audit/README.md
@@ -28,9 +28,7 @@
 
 #### General
 
-###### +Does the project implement their own certificates for the HTTPS protocol?
-
-###### +Does the project implement UUID(Universal Unique Identifier) for the user session?
+###### +Does the project implement its own certificates for the HTTPS protocol?
 
 ###### +Does the database present a password for protection?
 


### PR DESCRIPTION
The requirement was to check whether the session cookie contains a UUID:

https://github.com/01-edu/public/blob/ebcc577daeafd50ab057493e13e173767257a97d/subjects/forum/security/audit/README.md?plain=1#L21

If this condition is met, then UUIDs are already implemented in session management:

https://github.com/01-edu/public/blob/ebcc577daeafd50ab057493e13e173767257a97d/subjects/forum/security/audit/README.md?plain=1#L33

Therefore, this second "bonus" question about UUID implementation was removed, as it would always be redundant when the requirement is satisfied.