### PR TITLE
[EXTERNAL] fix sweet-curry test

### DIFF
--- a/js/tests/sweet-curry_test.js
+++ b/js/tests/sweet-curry_test.js
@@ -1,10 +1,6 @@
 export const tests = []
 const t = (f) => tests.push(f)
 
-t(() => mult2.length === 1)
-t(() => add3.length === 1)
-t(() => sub4.length === 1)
-
 t(({ eq }) => eq(mult2(2)(5), 10))
 t(({ eq }) => eq(mult2(3)(6), 18))
 t(({ eq }) => eq(mult2(4)(7), 28))


### PR DESCRIPTION
remove unnecessary function length check.
this code fails for no reason:
```js
const mult2 = (n = 0) => (n2) => n * n2
const add3 = (n = 0) => (n2) => (n3) => n + n2 + n3
const sub4 = (n = 0) => (n2) => (n3) => (n4) => n - n2 - n3 - n4

console.log(mult2.length); // 0
```