### PR TITLE
CON-#### `cloud-design` subject typo

### DIFF
--- a/subjects/devops/cloud-design/README.md
+++ b/subjects/devops/cloud-design/README.md
@@ -2,7 +2,7 @@
 
 <center>
 <img 
-    src="./resources/cloud-design.jpg?raw=true" style = "width: 600px
+    src="./resources/cloud-design.jpeg?raw=true" style = "width: 600px
     !important; height: 600px !important;"/>
 </center>
 


### PR DESCRIPTION
During the first implementation of this project, we had a problem rendering the image to the platform. We have updated the README.md (screenshot) to make this project pointing to the personnalized readme to be able to render the image. I suggest, to avoid any problem in the future, to apply this modification also on the reference.
![image](https://github.com/user-attachments/assets/04d2b928-0e30-4501-972a-08fa57e76fe3)
