### PR TITLE
[EXTERNAL] fix(`net-cat`): remove confusing quotes

### DIFF
--- a/subjects/net-cat/audit/README.md
+++ b/subjects/net-cat/audit/README.md
@@ -1,10 +1,10 @@
 #### Functional
 
-##### Try running `"./TCPChat"`.
+##### Try running `./TCPChat`.
 
 ###### Is the server listening for connections on the default port?
 
-##### Try running `"./TCPChat" 2525 localhost`.
+##### Try running `./TCPChat 2525 localhost`.
 
 ```
 [USAGE]: ./TCPChat $port
@@ -12,11 +12,11 @@
 
 ###### Did the server respond with usage, as above?
 
-##### Try running `"./TCPChat 2525"`.
+##### Try running `./TCPChat 2525`.
 
 ###### Is the server listening for connections on the port 2525?
 
-##### Try opening 3 terminals, run on the first terminal the command `"./TCPChat <port>"` and on the second and third terminal run the command `"nc <host ip> <port>"`.
+##### Try opening 3 terminals, run on the first terminal the command `./TCPChat <port>` and on the second and third terminal run the command `nc <host ip> <port>`.
 
 ###### Do both clients connect to the server with success?
 


### PR DESCRIPTION
Remove confusing quotes:

- "./TCPChat"
- "./TCPChat" 2525 localhost
- "./TCPChat 2525"

The first two commands are correct, but the third one will result in the error message `no such file or directory`. This happens because the shell interprets it as referring to a file literally named `"./TCPChat 2525`". The second and third commands are conflicting, enclosing both the executable name and its argument in a single set of quotes is not valid. For reference, please consult the [audit file](https://github.com/sadiqui/public/tree/master/subjects/push-swap/audit) of the push-swap project, where quotes are used only to ensure that an entire sequence is treated as a single argument.

PS: This issue was previously fixed in this [merged pull request #2824](https://github.com/01-edu/public/pull/2824) seems to have been unintentionally reintroduced by a more recent [pull request #2943](https://github.com/01-edu/public/pull/2943), likely due to being based on an older version of the audit file.