### PR TITLE
[EXTERNAL] 0-shell: bringing back the low-level system calls bonus for consistency

### DIFF
--- a/subjects/0-shell/README.md
+++ b/subjects/0-shell/README.md
@@ -57,6 +57,9 @@ Additional constraints:
 Implementing any of the following will be considered bonus:
 
 - Handle `Ctrl+C` (SIGINT) without crashing the shell
+- Implement the commands exclusively using `low-level system calls` avoiding built-in functions or libraries that abstract file operations.
+
+  - Instead of using functions like the Go `os.Open, os.Remove, and io.Copy`, you would use system calls directly through the `syscall` package using `syscall.Open, syscall.Close, syscall.Read, syscall.Write, syscall.Unlink`.
 - Shell usability enhancements:
   - **Auto-completion**
   - **Command history**


### PR DESCRIPTION
### Why?

This bonus was available around two weeks ago prior to the last doc update to the project requirement file. It was removed from the subject (perhaps by accident), however it is in the audit questions as a bonus, making an inconsistency between the readme and the audit questions. Adding this back will allow students to be aware of the bonus question prior to submission.

### Solution Overview

I just was copied the bonus point back from two versions ago from the file.
