### PR TITLE
[EXTERNAL] docs(`mini-framework`): fix subject and audit file

### DIFF
--- a/subjects/mini-framework/README.md
+++ b/subjects/mini-framework/README.md
@@ -9,7 +9,7 @@ Be aware that a framework is different from a library. When you call a method fr
 Your framework should implement:
 
 - Abstracting the DOM
-  Routing System
+- Routing System
 - State Management
 - Event Handling
 
@@ -17,7 +17,7 @@ You will also need to make a [todoMVC](http://todomvc.com/) project using your f
 
 ### Instructions
 
-You must create documentation for your framework, so that users (auditers) are able to understand and know how to use your framework without experiencing any awkwardness.
+You must create documentation for your framework, so that users (auditors) are able to understand and know how to use your framework without experiencing any awkwardness.
 
 Your framework will be tested by using it, like you previously have used one, in the social network project. So the user has to be presented to a folder structure that allows him to run the app from the root of that folder structure. The user testing your framework will have to implement some simple code in order to test the features described below.
 

--- a/subjects/mini-framework/audit/README.md
+++ b/subjects/mini-framework/audit/README.md
@@ -12,7 +12,7 @@
 
 ###### Does the documentation contain an explanation on how the framework works?
 
-##### Open the todoMVC project and compare it to other [todoMVC project](http://todomvc.com/) ([example](http://todomvc.com/examples/vanillajs/)).
+##### Open the todoMVC project and compare it to other [todoMVC project](http://todomvc.com/) ([example](https://todomvc.com/examples/javascript-es6/dist/)).
 
 ###### Does it contain every element as the other todoMVCs examples?
 


### PR DESCRIPTION
Fix minor documentation issues: standardized the "Routing System" header format, corrected a typo ("auditers" → "auditors"), and updated the TodoMVC example link to a valid one.