### PR TITLE
fix(modify_letter/main.rs): correct import syntax for modify_letter module

### DIFF
--- a/subjects/modify_letter/main.rs
+++ b/subjects/modify_letter/main.rs
@@ -1,4 +1,4 @@
-use modify_letter::*modify_letter*;
+use modify_letter::*;
 
 fn main() {
     println!("{}", remove_letter_sensitive("Jojhn jis sljeepjjing", 'j'));


### PR DESCRIPTION
[EXTERNAL] fix: correct import syntax for modify_letter module

### Why?

The original import statement used incorrect Rust syntax:  
`use modify_letter::*modify_letter*;`  
This caused a compile-time error.
Correcting this ensures that all public items from the `modify_letter` module are accessible as intended.

### Solution Overview

This pull request replaces the invalid import line with valid Rust wildcard import syntax:
```rust
use modify_letter::*;
```
No other parts of the code were modified.

### Implementation Details

Removed:
```rust
use modify_letter::*modify_letter*;
```
Added:
```rust
use modify_letter::*;
```

### Build Images

Not applicable — this change does not affect any build/test images.
