### PR TITLE
[EXTERNAL] Fix error message case to match expected test output

### DIFF
--- a/subjects/check_user_name/README.md
+++ b/subjects/check_user_name/README.md
@@ -17,7 +17,7 @@ You will also have to create a `User` struct which has:
   - `new`: which initializes the struct.
   - `send_name`: which takes only `self` as argument and returns an `Option<&str>` with `None` if the user is a `Guest` or the `name` if the `AccessLevel` has any of the other options.
 - Other functions:
-  - `check_user_name`: which takes a `User`, calls `send_name` and returns a `tuple` with `true` and the user `name` if `send_name` returns the name or `false` and `"Error: User is guest"` if not.
+  - `check_user_name`: which takes a `User`, calls `send_name` and returns a `tuple` with `true` and the user `name` if `send_name` returns the name or `false` and `"ERROR: User is guest"` if not.
 
 ### Expected Functions and Data Structures
 


### PR DESCRIPTION
Updated the `send_name` function to return `"ERROR: User is guest"` instead of `"Error: User is guest"` when the user is a guest, so it aligns with the expected output in the exercise tests.