### PR TITLE
CON-0000 | [EXTERNAL] Clarify row indexing and missing number in NumPy exercise

### DIFF
--- a/subjects/ai/numpy/README.md
+++ b/subjects/ai/numpy/README.md
@@ -296,7 +296,7 @@ The goal of this exercise is to perform fundamental data analysis on real data u
 
 The dataset chosen for this task was the [red wine dataset](./data/winequality-red.csv). You can find more info [HERE](./data/)
 
-1. Load the data using `genfromtxt`, specifying the delimiter as ';', and optimize the numpy array size by reducing the data types. Use `np.float32` and verify that the resulting numpy array weighs **76800 bytes**.
+1. Load the data using `genfromtxt`, specifying the delimiter as ';' with excluding the headers, and optimize the numpy array size by reducing the data types. Use `np.float32` and verify that the resulting numpy array weighs **76800 bytes**.
 
 2. Display the 2nd, 7th, and 12th rows as a two-dimensional array. Exclude `np.nan` values if present.
 


### PR DESCRIPTION
### **Commit Message:**

```
fix(numpy-docs): clarify row indexing instructions.

- Clarified instructions to specify exclusion of headers in row selection task
```


### **Why?**

The instruction "2. Display the 2nd, 7th, and 12th rows as a two-dimensional array" was unclear because in the first one "1. Load the data using `genfromtxt`, specifying the delimiter as ';', and optimize the numpy array size by reducing the data types. Use `np.float32` and verify that the resulting numpy array weighs **76800 bytes**."
It did not specify whether to include the header row in the count, which could confuse students or users working with `np.genfromtxt()` or similar CSV loading functions and this result the total change of the indexing output.

---

### **Solution Overview**

The instructional text was updated to clarify that the header should be excluded when counting rows.
New phrasing:

> "1. Load the data using `genfromtxt`, specifying the delimiter as ';' with excluding the headers, and optimize the numpy array size by reducing the data types. Use `np.float32` and verify that the resulting numpy array weighs **76800 bytes**."

---

### **Implementation Details**

* Original:
  `"1. Load the data using `genfromtxt`, specifying the delimiter as ';', and optimize the numpy array size by reducing the data types. Use `np.float32` and verify that the resulting numpy array weighs **76800 bytes**."`

* Updated:
  `"1. Load the data using `genfromtxt`, specifying the delimiter as ';' with excluding the headers, and optimize the numpy array size by reducing the data types. Use `np.float32` and verify that the resulting numpy array weighs **76800 bytes**."`

This change removes ambiguity and aligns with how NumPy functions like `np.genfromtxt(..., skip_header=1)` typically operate, where headers are not considered part of the data array.

No technical logic was changed—just improved documentation clarity.