### PR TITLE
[EXTERNAL] docs(`matrix-transposition`): precise title highlighting in notions links

### DIFF
--- a/subjects/matrix_transposition/README.md
+++ b/subjects/matrix_transposition/README.md
@@ -49,12 +49,12 @@ $
 
 - [Defining a struct](https://doc.rust-lang.org/stable/book/ch05-01-defining-structs.html)
 
-- [The Tuple Type](https://doc.rust-lang.org/stable/book/ch03-02-data-types.html#:~:text=the%20tuple%20type)
+- [The Tuple Type](https://doc.rust-lang.org/stable/book/ch03-02-data-types.html#the-tuple-type)
 
 - [Tuples](https://doc.rust-lang.org/rust-by-example/primitives/tuples.html)
 
-- [Tuple Structs without Named Fields](https://doc.rust-lang.org/stable/book/ch05-01-defining-structs.html#:~:text=using%20tuple%20structs%20without%20named%20fields%20to%20create%20different%20types)
+- [Tuple Structs without Named Fields](https://doc.rust-lang.org/stable/book/ch05-01-defining-structs.html#using-tuple-structs-without-named-fields-to-create-different-types)
 
-- [Adding Useful Functionality with Derived Traits](https://doc.rust-lang.org/stable/book/ch05-02-example-structs.html#:~:text=adding%20useful%20functionality%20with%20derived%20traits)
+- [Adding Useful Functionality with Derived Traits](https://doc.rust-lang.org/stable/book/ch05-02-example-structs.html#adding-useful-functionality-with-derived-traits)
 
-- [Chapter 7](https://doc.rust-lang.org/stable/book/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.html)
+- [Referring to an Item in the Module Tree](https://doc.rust-lang.org/stable/book/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.html)

--- a/subjects/matrix_transposition/README.md
+++ b/subjects/matrix_transposition/README.md
@@ -49,12 +49,12 @@ $
 
 - [Defining a struct](https://doc.rust-lang.org/stable/book/ch05-01-defining-structs.html)
 
-- [The Tuple Type](https://doc.rust-lang.org/stable/book/ch03-02-data-types.html?highlight=accessing%20a%20tuple#compound-types)
+- [The Tuple Type](https://doc.rust-lang.org/stable/book/ch03-02-data-types.html#:~:text=the%20tuple%20type)
 
 - [Tuples](https://doc.rust-lang.org/rust-by-example/primitives/tuples.html)
 
-- [Tuple Structs without Named Fields](https://doc.rust-lang.org/stable/book/ch05-01-defining-structs.html?highlight=tuple#using-tuple-structs-without-named-fields-to-create-different-types)
+- [Tuple Structs without Named Fields](https://doc.rust-lang.org/stable/book/ch05-01-defining-structs.html#:~:text=using%20tuple%20structs%20without%20named%20fields%20to%20create%20different%20types)
 
-- [Adding Useful Functionality with Derived Traits](https://doc.rust-lang.org/stable/book/ch05-02-example-structs.html?highlight=debug%20deriv#adding-useful-functionality-with-derived-traits)
+- [Adding Useful Functionality with Derived Traits](https://doc.rust-lang.org/stable/book/ch05-02-example-structs.html#:~:text=adding%20useful%20functionality%20with%20derived%20traits)
 
 - [Chapter 7](https://doc.rust-lang.org/stable/book/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.html)


### PR DESCRIPTION
Previously, URLs used the `highlight=` parameter to emphasize specific sentences in shared documentation links. However, this approach highlighted every individual occurrence of each word, rather than treating phrases as a single unit, leading to cluttered and imprecise highlights on the page.

This PR replaces the `highlight=` parameter with the `#:~:text=` fragment syntax, enabling exact phrase-level highlighting in supported browsers (Chrome, Edge, and others), while keeping source URLs the same.