### PR TITLE
[EXTERNAL] docs(`drawing/audit`): fix small typo, correct verb form

### DIFF
--- a/subjects/drawing/audit/README.md
+++ b/subjects/drawing/audit/README.md
@@ -10,7 +10,7 @@
 
 ##### Open the module `geometrical_shapes`.
 
-###### Can you confirm that the traits `Displayable` and `Drawable` where created?
+###### Can you confirm that the traits `Displayable` and `Drawable` were created?
 
 ##### Try to open the `image.png`.
 


### PR DESCRIPTION
**Wrong verb form:** "where" should be "were".
