### PR TITLE
fixed a wrong data type given in the instructions.

### DIFF
--- a/subjects/banner/README.md
+++ b/subjects/banner/README.md
@@ -22,7 +22,7 @@ println!("short hand: {}, long hand: {}, description: {}", d.short_hand, d.long_
 
 An associated **type** called `Callback` will also be provided. It should represent a function pointer which is going to be used in the structure and functions below. This function will represent the callback for the flag associated to it.
 
-A second structure named `FlagsHandler` will be given which just has one element: `flags: HashMap<(String, String), Callback>`. You'll also need to implement the following associated **functions**:
+A second structure named `FlagsHandler` will be given which just has one element: `flags: HashMap<String, Callback>`. You'll also need to implement the following associated **functions**:
 
 - `add_flag`, which adds the flag and callback function to the HashMap.
 - `exec_func`, which executes the function using the flag provided and returns the result. The callback should be executed with the first two arguments of the supplied `argv` argument. Return either the successful result from the callback or the error stringified.

--- a/subjects/drawing/README.md
+++ b/subjects/drawing/README.md
@@ -30,11 +30,14 @@ In order to compile and run `main.rs`, you'll need to define some structures. Yo
 
 You'll also need to create the associated function `random` for `Line`, `Point` and `Circle`. You should derive their signatures from the usage.
 
+Each shape must be drawn in a different color.
+
 > Don't forget to add the dependencies in your Cargo.toml.
 
 ### Bonus
 
 You may optionally implement the following shapes, including the structures and traits needed to draw them:
+
 - `Pentagon`
 - `Cube`
 
@@ -54,13 +57,13 @@ fn main() {
 
     gs::Point::random(image.width, image.height).draw(&mut image);
 
-    let rectangle = gs::Rectangle::new(&gs::Point::new(150, 150), &gs::Point::new(50, 50));
+    let rectangle = gs::Rectangle::new(&gs::Point::new(150, 300), &gs::Point::new(50, 60));
     rectangle.draw(&mut image);
 
-    let triangle = gs::Triangle::new (
-            &gs::Point::new(500, 500),
-            &gs::Point::new(250, 700),
-            &gs::Point::new(700, 800),
+    let triangle = gs::Triangle::new(
+        &gs::Point::new(500, 500),
+        &gs::Point::new(250, 700),
+        &gs::Point::new(700, 800),
     );
     triangle.draw(&mut image);
 


### PR DESCRIPTION
The instruction were requesting a HashMap with a tuple of strings as key and a value of a callback function but the expected function used a HashMap with string as key and callback as value.
The given instructions where misleading the users.

## The instructions:
- A second structure named `FlagsHandler` will be given which just has one element: `flags: HashMap<(String, String), Callback>`. You'll also need to implement the following associated **functions**:

## The given expected function:
```rust
pub struct FlagsHandler {
    pub flags: HashMap<String, Callback>,
}
```
So the fixed version of the instructions is :
- A second structure named `FlagsHandler` will be given which just has one element: `flags: HashMap<String, Callback>`. You'll also need to implement the following associated **functions**: