### PR TITLE
[EXTERNAL] fix(`chaikin`): update broken link + grammar correction

### DIFF
--- a/subjects/chaikin/README.md
+++ b/subjects/chaikin/README.md
@@ -13,7 +13,7 @@ You can see how the application should work [here](https://youtu.be/PbB2eKnA2QI)
 #### Functionality
 
 - The canvas must receive input from the mouse. The user must be able to use the left button to place control points for Chaikin's algorithm.
-  
+
 - The selected points must be visible on the canvas. You will need to draw a **small** circle surrounding each point.
 
 - If the canvas has control points drawn on it, then pressing `Enter` should start the animation. It should cycle through the steps until reaching the 7th step of `Chaikin's` algorithm. The animation should then restart.

--- a/subjects/chaikin/README.md
+++ b/subjects/chaikin/README.md
@@ -2,7 +2,7 @@
 
 ### Instructions
 
-Implement [Chaikin's](http://graphics.cs.ucdavis.edu/education/CAGDNotes/Chaikins-Algorithm/Chaikins-Algorithm.html) algorithm as a step by step animation.
+Implement [Chaikin's](https://www.cs.unc.edu/~dm/UNC/COMP258/LECTURES/Chaikins-Algorithm.pdf) algorithm as a step by step animation.
 
 You will create a canvas to enable the user to draw 1 or more points. The screen will then animate each step that is taken to obtain the final result of a drawn curve. The animation must play for 7 steps and then it must restart.
 
@@ -20,7 +20,7 @@ You can see how the application should work [here](https://youtu.be/PbB2eKnA2QI)
 
 - If the user presses `Enter` before any points have been drawn, then nothing should happen. It should still be possible to draw points. You may optionally choose to display a message to inform the user that they forgot to draw points.
 
-- If the canvas only has only one control point, the program must only present that point and not cycle through the steps.
+- If the canvas has only one control point, the program must only present that point and not cycle through the steps.
 
 - If the canvas has only two control points, the program must draw a straight line.
 


### PR DESCRIPTION
- **Updated** the Chaikin's Algorithm link to a working PDF version hosted by UNC.
  - From: http://graphics.cs.ucdavis.edu/education/CAGDNotes/Chaikins-Algorithm/Chaikins-Algorithm.html
  - To: https://www.cs.unc.edu/~dm/UNC/COMP258/LECTURES/Chaikins-Algorithm.pdf
- **Fixed** a grammar redundancy: "only has only" → "has only".