### PR TITLE
[EXTERNAL] fix(`box_recursion`): fix expected code

### DIFF
--- a/subjects/box_recursion/README.md
+++ b/subjects/box_recursion/README.md
@@ -30,11 +30,11 @@ pub struct WorkEnvironment {
     pub grade: Link,
 }
 
-pub type Link;
+pub type Link = _; // Complete type alias
 
 #[derive(Debug)]
 pub struct Worker {
-    pub role: String,
+    pub role: Role,
     pub name: String,
     pub next: Link,
 }


### PR DESCRIPTION
**1.** Make it clear, that student should complete this type alias, guided by instructions:
```
Additionally, create a type named Link, which will be the connection between the WorkEnvironment and Worker structures. It will point to None if there is no Worker to point to.
```

```diff
- pub type Link;
+ pub type Link = _; // Complete type alias
```

**2.** role field of Worker structure, is expected to be of type Role. Tests Need It as checks expect "Role::CEO, not "CEO".

```diff
- pub role: String,
+ pub role: Role,
```

----

Related files:
- Tests: https://github.com/01-edu/rust-tests/blob/master/tests/box_recursion_test/src/lib.rs
- Solution: https://github.com/01-edu/rust-tests/blob/master/solutions/box_recursion/src/lib.rs
