### PR TITLE
[EXTERNAL] fix(keras-2): correct typo in README (no → not and go → goal)

### DIFF
--- a/subjects/ai/keras-2/README.md
+++ b/subjects/ai/keras-2/README.md
@@ -111,7 +111,7 @@ The data set is [Auto MPG Dataset](auto-mpg.csv) and the go is to build a model 
 
 2. Train a neural network on the train set and predict on the test set. The neural network should have 2 hidden layers and the loss should be **mean_squared_error**. The expected **mean absolute error** on the test set is maximum 10.
    _Hint_: increase the number of epochs
-   **Warning**: Do no forget to evaluate the neural network on the **SCALED** test set.
+   **Warning**: Do not forget to evaluate the neural network on the **SCALED** test set.
 
 ---
 
@@ -166,7 +166,7 @@ Preliminary:
 
 2. Train a neural network on the train set and predict on the test set. The neural network should have 1 hidden layers. The expected **accuracy** on the test set is minimum 90%.
    _Hint_: increase the number of epochs
-   **Warning**: Do no forget to evaluate the neural network on the **SCALED** test set.
+   **Warning**: Do not forget to evaluate the neural network on the **SCALED** test set.
 
 ### Resources
 

--- a/subjects/ai/keras-2/README.md
+++ b/subjects/ai/keras-2/README.md
@@ -99,7 +99,7 @@ Hint:
 ### Exercise 2: Regression example
 
 The goal of this exercise is to learn to train a neural network to perform a regression on a data set.
-The data set is [Auto MPG Dataset](auto-mpg.csv) and the go is to build a model to predict the fuel efficiency of late-1970s and early 1980s automobiles. To do this, provide the model with a description of many automobiles from that time period. This description includes attributes like: cylinders, displacement, horsepower, and weight.
+The data set is [Auto MPG Dataset](auto-mpg.csv) and the goal is to build a model to predict the fuel efficiency of late-1970s and early 1980s automobiles. To do this, provide the model with a description of many automobiles from that time period. This description includes attributes like: cylinders, displacement, horsepower, and weight.
 
 - [Keras](https://www.tensorflow.org/tutorials/keras/regression)
 

--- a/subjects/ai/keras-2/README.md
+++ b/subjects/ai/keras-2/README.md
@@ -104,7 +104,6 @@ The data set is [Auto MPG Dataset](auto-mpg.csv) and the goal is to build a mode
 - [Keras](https://www.tensorflow.org/tutorials/keras/regression)
 
 1. Preprocess the data set as follow:
-
    - Drop the columns: **model year**, **origin**, **car name**
    - Split train test without shuffling the data. Keep 20% for the test set.
    - Scale the data using Standard Scaler
@@ -126,7 +125,6 @@ The goal of this exercise is to learn to a neural network architecture for multi
 Let us assume we want to classify images and we know they contain either apples, bears, candies, eggs or dogs (extension of the example in the link above).
 
 1. Create the architecture for a multi-class neural network with the following architecture and return `print(model.summary())`:
-
    - Five inputs variables.
    - Hidden layer 1: 16 neurons and sigmoid as activation function.
    - Hidden layer 2: 8 neurons and sigmoid as activation function.


### PR DESCRIPTION
Solution Overview
This pull request addresses a documentation typo in the README.md file.
The word “no” was mistakenly used instead of “not”, which could lead to confusion for readers.

The solution implemented is straightforward:

Corrected “no” → “not” in the affected sentence.
Corrected “go” → “goal” in the affected sentence.
No additional modifications were made to the surrounding content.
This ensures the documentation is clearer and more accurate for users referencing it.