### PR TITLE
[EXTERNAL] fix(pandas): replace broken "Ultimate Pandas Resource" link with "Awesome Pandas"

### DIFF
--- a/subjects/previousprime/README.md
+++ b/subjects/previousprime/README.md
@@ -2,7 +2,7 @@
 
 ### Instructions
 
-Create a **function** which returns the first prime number which is less than or equal to the `u64` passed as an argument.
+Create a **function** which returns the biggest prime number which is smaller than the `u64` passed as an argument.
 
 If there are no smaller primes, the function should return `0`.
 
@@ -13,13 +13,13 @@ If there are no smaller primes, the function should return `0`.
 
 ```rust
 pub fn prev_prime(nbr: u64) -> u64  {
-
+    todo!()
 }
 ```
 
 ### Usage
 
-Here is a possible program to test your function :
+Here is a possible program to test your function:
 
 ```rust
 use previousprime::*;
@@ -29,7 +29,7 @@ fn main() {
 }
 ```
 
-And its output :
+And its output:
 
 ```console
 $ cargo run

--- a/subjects/previousprime/main.rs
+++ b/subjects/previousprime/main.rs
@@ -1,5 +1,0 @@
-use previousprime::*;
-
-fn main() {
-    println!("The previous prime number before 34 is: {}", prev_prime(34));
-}


### PR DESCRIPTION
Thanks for catching this!  
The "Ultimate Pandas Resource" link was returning a 403 error.  
I’ve updated it to point to the actively maintained [Awesome Pandas](https://github.com/tommyod/awesome-pandas) resource instead.
