### PR TITLE
docs: update DateFormatter output in README

### DIFF
--- a/subjects/java/checkpoints/date-formatter/README.md
+++ b/subjects/java/checkpoints/date-formatter/README.md
@@ -64,8 +64,8 @@ $ javac *.java -d build
 $ java -cp build ExerciseRunner
 28/06/2022
 28.06.2022
-31.12.2022
-31 December 2022
+01.01.2023
+01 January 2023
 $
 ```
 


### PR DESCRIPTION
# DateFormatter Output Update

## 🧩 Overview
The example output for the `DateFormatter` in the README was outdated.  
It has been updated to reflect the correct output.

## ✅ Updated Output

**Before:**
```text
31.12.2022
31 December 2022
```
**After:**
```text
01.01.2023
01 January 2023