### PR TITLE
[EXTERNAL] Add missing 'Kg to Pounds' conversion

### DIFF
--- a/subjects/java/checkpoints/unit-converter/README.md
+++ b/subjects/java/checkpoints/unit-converter/README.md
@@ -8,9 +8,10 @@ In a file named `UnitConverter.java`, write a function `convert` that returns th
 
 - Fahrenheit to Celsius: (F - 32) \* 5/9
 - Celsius to Fahrenheit: C \* 9/5 + 32
-- Kilometers to Miles: K \* 0.621371
+- Kilometers to Miles: Km \* 0.621371
 - Miles to Kilometers: M \* 1.60934
 - Pounds to Kilograms: P \* 0.45359237
+- Kilograms to Pounds: Kg \* 2.204622622
 
 ### Expected Functions
 


### PR DESCRIPTION
Pounds to Kilograms and vice versa (like the others)


[EXTERNAL] Add Pounds ↔ Kilograms conversion

### Why?

> Other conversions like have the conversion back (e.g. Fahrenheit to Celsius and Celsius to Fahrenheit) except Pounds to Kilograms, so it sounds like 'Kilograms to Pounds' is missing


### Solution Overview

> Added a 'Kilograms to Pounds' conversion

### Implementation Details

> --

### Build Images

> --
