### PR TITLE
[EXTERNAL] fix small typo in the subject README.md

### DIFF
--- a/subjects/java/piscine/StreamCollect/README.md
+++ b/subjects/java/piscine/StreamCollect/README.md
@@ -49,7 +49,7 @@ $ javac *.java -d build
 $ java -cp build ExerciseRunner
 {B=[Bonjour, bonsoir], L=[le], M=[monde !]}
 {0=Optional[424], 1=Optional[97], 2=Optional[48354], 3=Optional[5843]}
-##{Bordeaux # Hello # how are you ? # where do you live ?}
+{Bordeaux # Hello # how are you ? # where do you live ?}
 $
 ```
 


### PR DESCRIPTION
## Fix typo in StreamCollect subject README
# Why?

A small typo was present in the ```subjects/java/piscine/StreamCollect/README.md``` file.
It wasted almost as much of my time as i am wasting yours dear maintainer.

# Solution Overview
fix world hunger then use any extra time to fix this

ps : minoch says hi
#### ʕ·͡˔·ོɁ✧