### PR TITLE
[EXTERNAL] Fix return type of getTransport method in README

### DIFF
--- a/subjects/java/piscine/Factory/README.md
+++ b/subjects/java/piscine/Factory/README.md
@@ -34,7 +34,7 @@ class DriverFactory {
 }
 
 class TransportFactory {
-  + getTransport(Type: String) int
+  + getTransport(Type: String) Transport
 }
 
 Driver <|-- CarDriver


### PR DESCRIPTION
A factory class is a class whose main job is to create and return objects.
