### PR TITLE
[EXTERNAL] Refactor constructor names in Decorator classes

### DIFF
--- a/subjects/java/piscine/Decorator/README.md
+++ b/subjects/java/piscine/Decorator/README.md
@@ -23,14 +23,14 @@ class RacletteDecorator {
     +getIngredients() String
 }
 class WithPickles {
-    -Raclette raclette
-    +RacletteDecorator(Raclette raclette)
+    -Raclette decoratedRaclette
+    +WithPickles(Raclette raclette)
     +getCalories() int
     +getIngredients() String
 }
 class WithColdMeats {
     -Raclette decoratedRaclette
-    +RacletteDecorator(Raclette raclette)
+    +WithColdMeats(Raclette raclette)
     +getCalories() int
     +getIngredients() String
 }


### PR DESCRIPTION
Renamed constructors in Decorator classes to follow consistent naming patterns, making the codebase more uniform and easier to understand.
