### PR TITLE
[EXTERNAL] docs (numpy): Update README.md, updated the python version

### DIFF
--- a/subjects/ai/numpy/audit/README.md
+++ b/subjects/ai/numpy/audit/README.md
@@ -8,7 +8,7 @@
 
 ##### Run `python --version`
 
-###### Does it print `Python 3.x`? x >= 9
+###### Does it print `Python 3.x`? x >= 8
 
 ###### Does `import jupyter` and `import numpy` run without any error?
 


### PR DESCRIPTION
### Changes

> Changed the python version in audit from "3.x ? x >= 9" to "3.x ? x >= 8"

### Solution Overview

> The README.md of the "numpy" project had the educational Python version of 3.8. However, audit needs at least the version of 3.9 which contradicts to the README of "numpy". Thus, the minimal version of Python needed in audit README.md was changed from 3.9 to 3.8 to correspond to the README.md of numpy.
