### PR TITLE
docs (ai/numpy): Fix typo in dtype for numpy arrays & Updates Py version

### DIFF
--- a/subjects/ai/numpy/README.md
+++ b/subjects/ai/numpy/README.md
@@ -52,7 +52,6 @@ We suggest utilizing:
 - [jupyter](https://jupyter.org/)
 - [numpy](https://numpy.org/)
 - [Jupyter Notebook Shortcuts](https://towardsdatascience.com/jypyter-notebook-shortcuts-bf0101a98330)
-- [Why You Should be Using Jupyter Notebooks](https://odsc.medium.com/why-you-should-be-using-jupyter-notebooks-ea2e568c59f2)
 
 ---
 


### PR DESCRIPTION
## Changes :

- This PR fixes a typo in the NumPy array initialization where the dtype keyword argument was misspelled as dytpe.
- The correction ensures the array is properly created with the intended np.int8 data type and prevents a runtime TypeError.
- Updated the required Python version in the audit from 3.x (x ≥ 9) to 3.x (x ≥ 8).