### PR TITLE
[EXTERNAL] Fix incorrect -r flag in mv instructions

### DIFF
--- a/subjects/devops/change-struct/README.md
+++ b/subjects/devops/change-struct/README.md
@@ -61,7 +61,6 @@ cp -r `repo to copy` `path of destination`
 
 ```console
 $ mv `file to move` `path of destination`
-$ mv -r `repo to move` `path of destination`
 $ ls
 text.txt old_repo
 $ mv text.txt new_text.txt


### PR DESCRIPTION
### Why?

> The instructions for moving directories incorrectly suggested using mv -r, which does not exist. This fix removes the invalid flag

### Solution Overview

> Updated the “Move or Rename” section in the instructions:

- Removed the line suggesting mv with -r for directories

- Kept the mv example for files, since it works for all types of files and directories

### Implementation Details


> Only subject/instructions were updated.

- Removed the mv -r line that incorrectly suggested using -r for directories.

- Kept the mv example for files, which works for both files and directories.

- Verified that all mv commands now work correctly in bash without errors.
- 
### Build Images

> N/A – documentation-only change