### PR TITLE
[EXTERNAL] fix: clarify file-details subject hints misleading comment  and correct awk examples qouting

### DIFF
--- a/subjects/devops/file-details/README.md
+++ b/subjects/devops/file-details/README.md
@@ -49,15 +49,15 @@ You can specify specific column names to display or include in the awk output us
 $ ls -l | awk '{print $1, $2, $3, $4, $5, $6, $7, $8, $9}' # print all the given fields
 total 4
 -rw-rw-r-- 1 user user 1989 dez 20 15:19 README.md
-$ ls -l | awk '{print $1, $2, $4, $5, $7, $8}'             # print all the given fields
+$ ls -l | awk '{print $1, $2, $4, $5, $7, $8}'             # print selected fields: perms, links, group, size, day, time
 total 4
 -rw-rw-r-- 1 user 2350 20 15:25
 $
 ```
-
-awk ‘{print $1}’ emp_records.txt
-awk {print $1, $6, $7, $8, $9}'
-
+```console
+awk '{print $1}' emp_records.txt
+awk '{print $1, $6, $7, $8, $9}'
+```
 > You have to use Man or Google to know more about commands flags, in order to solve this exercise!
 > Google and Man will be your friends!
 


### PR DESCRIPTION
### Why?  
The original `file-details/README.md` exercise instructions contained misleading comments about `awk` field usage and included incorrect quotes in examples. This could confuse learners and cause syntax errors when following the hints.  

### Solution Overview  
- Corrected the comments describing `awk` fields to reflect what is actually printed.  
- Replaced smart quotes with straight quotes in all `awk` examples.  
- Reorganized examples for better readability and clarity for beginners.  

### Implementation Details  
- Updated all `awk` example commands to use proper shell-compatible quotes. 
- Clarified which columns are selected in each `awk` example, avoiding misleading “all fields” comments. 

### Build Images  
> N/A. 
