### PR TITLE
[EXTERNAL] Updated README.md for vision-track

### DIFF
--- a/subjects/ai/vision-track/README.md
+++ b/subjects/ai/vision-track/README.md
@@ -182,6 +182,7 @@ vision-track/
 │    ├── roi_counting_example.png
 │    └── multi_stream_demo.mp4
 │
+├── logs/app_errors.log
 ├── app.py
 ├── README.md                # Project overview and setup instructions
 └── requirements.txt         # List of dependencies


### PR DESCRIPTION
fixed readme

The readme stated there must be logging and it should be saved in:
logs/app_errors.log

But the structure did not have "logs/app_errors.log", so i added it