### PR TITLE
 [EXTERNAL] fix: clarify set-internal-vars expected output, remove misleading commas

### DIFF
--- a/subjects/devops/set-internal-vars/README.md
+++ b/subjects/devops/set-internal-vars/README.md
@@ -16,7 +16,7 @@ $ ./set-internal-vars.sh
 Hello World
 100
 3.142
-one, two, three, four, five
+one two three four five
 $
 ```
 


### PR DESCRIPTION
### Why?

The expected output in the exercise documentation was misleading: it showed the array elements with commas `one, two, three, four, five` while the actual test expects them to be space-separated `one two three four five`. This change clarifies the expected output to prevent confusion when implementing the script.

### Solution Overview

Updated the instructions and expected output for `set-internal-vars.sh` to remove commas between array elements. The script now clearly indicates that the array should be printed as space-separated values, matching the automated test expectations.

### Implementation Details
- Removed commas from the example output in the exercise description.

### Build Images

> N/A
