### PR TITLE
fix: correct typo "Don not" → "Do not" in audit README test case

### DIFF
--- a/subjects/go-reloaded/audit/README.md
+++ b/subjects/go-reloaded/audit/README.md
@@ -14,9 +14,9 @@
 
 ###### Is the text present in `result.txt` equal to the above?
 
-##### In a file called `sample.txt` place the following text: `Don not be sad ,because sad backwards is das . And das not good`. Now run the student program with the arguments: `sample.txt result.txt`.
+##### In a file called `sample.txt` place the following text: `Do not be sad ,because sad backwards is das . And das not good`. Now run the student program with the arguments: `sample.txt result.txt`.
 
-`Don not be sad, because sad backwards is das. And das not good`
+`Do not be sad, because sad backwards is das. And das not good`
 
 ###### Is the text present in `result.txt` equal to the above?
 


### PR DESCRIPTION
[EXTERNAL] fix: correct typo "Don not" → "Do not" in audit README test case

### Why?
The audit README contains a typo in a test case input and expected output. 
The text reads "Don not be sad..." which is grammatically incorrect and 
confusing for students and auditors using this as a reference.

### Solution Overview
Corrected the typo "Don not" to "Do not" in both the input text and the 
expected output of the affected test case in 
`subjects/go-reloaded/audit/README.md`.

### Implementation Details
Simple one-word typo fix. No alternative approaches were considered as 
this is a straightforward documentation correction.

### Build Images
N/A - This is a documentation-only change, no build images required.