### PR TITLE
Fix issue #3163: corrected the IP-domain rlation statement

### DIFF
--- a/subjects/login/README.md
+++ b/subjects/login/README.md
@@ -42,7 +42,7 @@ Behind every name in a computer system there is a number (ID, index, address, et
 
 Names exist because they are human readable, but behind the scenes they are converted into numbers, unique in their namespace :
 
-- A domain name can have several IP addresses, but an IP address can only identify one domain name
+- A domain name can map to several IP addresses (for load balancing), and a single IP address can host many different domain names (via Virtual Hosting).
 - Several processes may have the same name, but a PID identifies a single process
 
 Find the commands to get :


### PR DESCRIPTION
CON-3163 | Corrected IP-Domain mapping documentation
====================================================

### Why?

The existing documentation contained a logical inaccuracy regarding the relationship between domain names and IP addresses. It stated that an IP address can only identify one domain name, which ignores the industry-standard practice of **Virtual Hosting**. This change ensures the technical documentation correctly reflects how modern web servers and DNS function.

### Solution Overview

I have updated the descriptive text to clarify that the relationship between domain names and IP addresses is **many-to-many**.

The corrected statement now explains that:

1.  **One Domain** can resolve to **Multiple IPs** (for load balancing).
    
2.  **One IP** can host **Multiple Domains** (via Virtual Hosting/SNI).
    

### Implementation Details

The revision replaces the restrictive "one-to-one" implication with a more accurate "many-to-many" explanation.

*   **Approach Chosen:** Directly addressing the "Virtual Hosting" concept. This was chosen over a simple deletion because explaining _why_ the numbers match the names provides better educational value for the project.
    
*   **Alternatives Considered:** I considered adding a deep dive into SNI (Server Name Indication), but decided against it to keep the "Just Numbers" section concise and focused on the core concept of identifiers.