### PR TITLE
docs(ion-out): clarify that words must end in tion

### DIFF
--- a/subjects/ion-out/README.md
+++ b/subjects/ion-out/README.md
@@ -2,7 +2,7 @@
 
 ### Instructions
 
-Create a function named `ionOut`, that receives a `string` and returns an array with every word containing `'ion'` following a `'t'`. The words should be returned without the `'ion'` part.
+Create a function named `ionOut`, that receives a `string` and returns an array containing every word that ends in `'tion'`. Each returned word should have its trailing `'ion'` removed.
 
 ### Notions
 


### PR DESCRIPTION
**Title:**

```
[EXTERNAL] Clarify ion-out README wording
```

### Why?

The current README is ambiguous. It says to return every word containing `ion` following a `t`, with the `ion` part removed. Read literally, this implies that words such as:

```text
mentions -> ments
```
should be included. However, the test suite only accepts words where `tion` occurs at the end of the word. 

### Solution Overview

Clarify that only words ending in `tion` are expected. The revised wording makes the documented requirements match the tests and makes the intended use of a lookahead clearer.